### PR TITLE
[https://github.com/gambol99/go-marathon/issues/16]

### DIFF
--- a/client.go
+++ b/client.go
@@ -330,6 +330,7 @@ func (client *Client) httpCall(method, uri, body string) (int, string, *http.Res
 			return 0, "", nil, err
 		} else {
 			request.Header.Add("Content-Type", "application/json")
+			request.Header.Add("Accept", "application/json")
 			var content string
 			/* step: perform the request */
 			if response, err := client.http.Do(request); err != nil {

--- a/task.go
+++ b/task.go
@@ -25,9 +25,9 @@ type Tasks struct {
 }
 
 type Task struct {
+	ID                string               `json:"id"`
 	AppID             string               `json:"appId"`
 	Host              string               `json:"host"`
-	ID                string               `json:"id"`
 	HealthCheckResult []*HealthCheckResult `json:"healthCheckResults"`
 	Ports             []int                `json:"ports"`
 	ServicePorts      []int                `json:"servicePorts"`


### PR DESCRIPTION
- /v2/tasks by default hands back plain text; adding a 'accept' json in the request headers