### PR TITLE
WIP: Add query string params for API

### DIFF
--- a/application.go
+++ b/application.go
@@ -19,6 +19,7 @@ package marathon
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 )
 
@@ -241,17 +242,17 @@ func (application *Application) CheckTCP(port, interval int) (*Application, erro
 }
 
 // Retrieve an array of all the applications which are running in marathon
-func (client *Client) Applications() (*Applications, error) {
+func (client *Client) Applications(v url.Values) (*Applications, error) {
 	applications := new(Applications)
-	if err := client.apiGet(MARATHON_API_APPS, nil, applications); err != nil {
+	if err := client.apiGet(MARATHON_API_APPS+"?"+v.Encode(), nil, applications); err != nil {
 		return nil, err
 	}
 	return applications, nil
 }
 
 // Retrieve an array of the application names currently running in marathon
-func (client *Client) ListApplications() ([]string, error) {
-	if applications, err := client.Applications(); err != nil {
+func (client *Client) ListApplications(v url.Values) ([]string, error) {
+	if applications, err := client.Applications(v); err != nil {
 		return nil, err
 	} else {
 		list := make([]string, 0)
@@ -419,7 +420,7 @@ func (client *Client) HasApplication(name string) (bool, error) {
 	if name == "" {
 		return false, ErrInvalidArgument
 	}
-	if applications, err := client.ListApplications(); err != nil {
+	if applications, err := client.ListApplications(nil); err != nil {
 		return false, err
 	} else {
 		for _, id := range applications {

--- a/application_test.go
+++ b/application_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestApplications(t *testing.T) {
 	client := NewFakeMarathonEndpoint(t)
-	applications, err := client.Applications()
+	applications, err := client.Applications(nil)
 	assertOnError(err, t)
 	assertOnNull(applications, t)
 	assertOnInteger(len(applications.Apps), 2, t)
@@ -30,7 +30,7 @@ func TestApplications(t *testing.T) {
 
 func TestListApplications(t *testing.T) {
 	client := NewFakeMarathonEndpoint(t)
-	applications, err := client.ListApplications()
+	applications, err := client.ListApplications(nil)
 	assertOnError(err, t)
 	assertOnNull(applications, t)
 	assertOnInteger(len(applications), 2, t)

--- a/client.go
+++ b/client.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -42,7 +43,7 @@ type Marathon interface {
 	/* check it see if a application exists */
 	HasApplication(name string) (bool, error)
 	/* get a listing of the application ids */
-	ListApplications() ([]string, error)
+	ListApplications(url.Values) ([]string, error)
 	/* a list of application versions */
 	ApplicationVersions(name string) (*ApplicationVersions, error)
 	/* check a application version exists */
@@ -64,7 +65,7 @@ type Marathon interface {
 	/* restart an application */
 	RestartApplication(name string, force bool) (*DeploymentID, error)
 	/* get a list of applications from marathon */
-	Applications() (*Applications, error)
+	Applications(url.Values) (*Applications, error)
 	/* get a specific application */
 	Application(name string) (*Application, error)
 	/* wait of application */


### PR DESCRIPTION
Related to #23.

Can we reuse `url.Values` directly, @gambol99? Should we add it to every api call?