### PR TITLE
empty array means no ports

### DIFF
--- a/application.go
+++ b/application.go
@@ -50,7 +50,7 @@ type Application struct {
 	Instances             int                 `json:"instances,omitemptys"`
 	Mem                   float32             `json:"mem,omitempty"`
 	Tasks                 []*Task             `json:"tasks,omitempty"`
-	Ports                 []int               `json:"ports,omitempty"`
+	Ports                 []int               `json:"ports"`
 	RequirePorts          bool                `json:"requirePorts,omitempty"`
 	BackoffSeconds        float32             `json:"backoffSeconds,omitempty"`
 	BackoffFactor         float32             `json:"backoffFactor,omitempty"`


### PR DESCRIPTION
This is a confusing behavior of marathon in my opinion. If you don't
supply any `ports` attribute, it will default to allocating you one
port. However, if you don't want any ports, you have to supply `ports`
with an empty array. The way it was with the `omitempty`, it wouldn't
allow you to do that.

This PR fixes that.