### PR TITLE
Change KillTask to extract the application name from the task ID

### DIFF
--- a/client.go
+++ b/client.go
@@ -81,7 +81,7 @@ type Marathon interface {
 	/* kill all the tasks for any application */
 	KillApplicationTasks(application_id, hostname string, scale bool) (*Tasks, error)
 	/* kill a single task */
-	KillTask(application_id, task_id string, scale bool) (*Task, error)
+	KillTask(task_id string, scale bool) (*Task, error)
 	/* kill the given array of tasks */
 	KillTasks(task_ids []string, scale bool) error
 

--- a/task.go
+++ b/task.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 type Tasks struct {
@@ -94,14 +95,15 @@ func (client *Client) KillApplicationTasks(id, hostname string, scale bool) (*Ta
 // Kill the task associated with a given ID
 // 	task_id:		the id for the task
 // 	scale:		Scale the app down
-func (client *Client) KillTask(appId, taskId string, scale bool) (*Task, error) {
+func (client *Client) KillTask(taskId string, scale bool) (*Task, error) {
 	var options struct {
 		Scale bool  `json:bool`
 	}
 	options.Scale = scale
 	task := new(Task)
-	client.log("KillTask Killing task `%s` for: %s, scale: %t", taskId, appId, scale)
-	if err := client.apiDelete(fmt.Sprintf("%s/%s/tasks/%s", MARATHON_API_APPS, trimRootPath(appId), taskId), &options, task); err != nil {
+	appName := taskId[0:strings.LastIndex(taskId, ".")]
+	client.log("KillTask Killing task `%s` for: %s, scale: %t", taskId, appName, scale)
+	if err := client.apiDelete(fmt.Sprintf("%s/%s/tasks/%s", MARATHON_API_APPS, appName, taskId), &options, task); err != nil {
 		return nil, err
 	}
 	return task, nil


### PR DESCRIPTION
Change KillTask to extract the application name from the task ID rather than accept it as a parameter