### PR TITLE
add DefaultDeploymentTimeout to client config

### DIFF
--- a/application.go
+++ b/application.go
@@ -385,7 +385,7 @@ func (client *Client) CreateApplication(application *Application, wait_on_runnin
 //		timeout:	a duration of time to wait for an application to deploy
 func (client *Client) WaitOnApplication(name string, timeout time.Duration) error {
 	if timeout <= 0 {
-		timeout = time.Duration(300) * time.Second
+		timeout = client.config.DefaultDeploymentTimeout
 	}
 	// step: this is very naive approach - the problem with using deployment id's is
 	// one) from > 0.8.0 you can be handed a deployment Id on creation, but it may or may not exist in /v2/deployments

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ package marathon
 import (
 	"io"
 	"io/ioutil"
+	"time"
 )
 
 type Config struct {
@@ -32,6 +33,8 @@ type Config struct {
 	LogOutput io.Writer
 	/* the timeout for requests */
 	RequestTimeout int
+	/* the default timeout for deployments */
+	DefaultDeploymentTimeout time.Duration
 	/* http basic auth */
 	HttpBasicAuthUser string
 	/* http basic password */
@@ -40,11 +43,12 @@ type Config struct {
 
 func NewDefaultConfig() Config {
 	return Config{
-		URL:               "http://127.0.0.1:8080",
-		EventsPort:        10001,
-		EventsInterface:   "eth0",
-		LogOutput:         ioutil.Discard,
-		HttpBasicAuthUser: "",
-		HttpBasicPassword: "",
-		RequestTimeout:    5}
+		URL:                      "http://127.0.0.1:8080",
+		EventsPort:               10001,
+		EventsInterface:          "eth0",
+		LogOutput:                ioutil.Discard,
+		HttpBasicAuthUser:        "",
+		HttpBasicPassword:        "",
+		DefaultDeploymentTimeout: time.Duration(300) * time.Second,
+		RequestTimeout:           5}
 }


### PR DESCRIPTION
Sometimes it would be nice to override the default of 5 minutes instead
of and then just be able to call CreateApplication with
wait_on_running=true.