### PR TITLE
Added LastTaskFailure in the Application struct 

### DIFF
--- a/application.go
+++ b/application.go
@@ -48,7 +48,7 @@ type Application struct {
 	Env                   map[string]string   `json:"env,omitempty"`
 	Executor              string              `json:"executor,omitempty"`
 	HealthChecks          []*HealthCheck      `json:"healthChecks,omitempty"`
-	Instances             int                 `json:"instances,omitemptys"`
+	Instances             int                 `json:"instances,omitempty"`
 	Mem                   float64             `json:"mem,omitempty"`
 	Tasks                 []*Task             `json:"tasks,omitempty"`
 	Ports                 []int               `json:"ports"`
@@ -66,6 +66,7 @@ type Application struct {
 	Version               string              `json:"version,omitempty"`
 	Labels                map[string]string   `json:"labels,omitempty"`
 	AcceptedResourceRoles []string            `json:"acceptedResourceRoles,omitempty"`
+	LastTaskFailure       *LastTaskFailure    `json:"lastTaskFailure,omitempty"`
 }
 
 type ApplicationVersions struct {

--- a/last_task_failure.go
+++ b/last_task_failure.go
@@ -1,0 +1,26 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+type LastTaskFailure struct {
+	AppId     string `json:"appId,omitempty"`
+	Host      string `json:"host,omitempty"`
+	Message   string `json:"message,omitempty"`
+	State     string `json:"string,omitempty"`
+	TaskId    string `json:"taskId,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+	Version   string `json:"version,omitempty"`
+}


### PR DESCRIPTION
Added LastTaskFailure in the Application struct  to get information on the failure of some tasks given that this information is exposed by the REST API. 

Also, fixed a typo. 