### PR TITLE
Fixed wrong json tag in last_task_failure.

### DIFF
--- a/last_task_failure.go
+++ b/last_task_failure.go
@@ -19,7 +19,7 @@ type LastTaskFailure struct {
 	AppId     string `json:"appId,omitempty"`
 	Host      string `json:"host,omitempty"`
 	Message   string `json:"message,omitempty"`
-	State     string `json:"string,omitempty"`
+	State     string `json:"state,omitempty"`
 	TaskId    string `json:"taskId,omitempty"`
 	Timestamp string `json:"timestamp,omitempty"`
 	Version   string `json:"version,omitempty"`


### PR DESCRIPTION
In the previous PR, there was a wrong json tag, which didn't allow the "state" of LastTaskFailure to be correctly decoded. 