### PR TITLE
returning the deployment id

### DIFF
--- a/application.go
+++ b/application.go
@@ -368,17 +368,17 @@ func (client *Client) ApplicationDeployments(name string) ([]*DeploymentID, erro
 // Creates a new application in Marathon
 // 		application: 		the structure holding the application configuration
 //		wait_on_running:	waits on the application deploying, i.e. the instances arre all running (note health checks are excluded)
-func (client *Client) CreateApplication(application *Application, wait_on_running bool) error {
+func (client *Client) CreateApplication(application *Application, wait_on_running bool) (*Application, error) {
 	result := new(Application)
 	client.log("Creating an application: %s", application)
 	if err := client.apiPost(MARATHON_API_APPS, &application, result); err != nil {
-		return err
+		return nil, err
 	}
 	// step: are we waiting for the application to start?
 	if wait_on_running {
-		return client.WaitOnApplication(application.ID, 0)
+		return nil, client.WaitOnApplication(application.ID, 0)
 	}
-	return nil
+	return result, nil
 }
 
 // Wait for an application to be deployed
@@ -481,18 +481,18 @@ func (client *Client) ScaleApplicationInstances(name string, instances int) (*De
 // Updates a new application in Marathon
 // 		application: 		the structure holding the application configuration
 //		wait_on_running:	waits on the application deploying, i.e. the instances arre all running (note health checks are excluded)
-func (client *Client) UpdateApplication(application *Application, wait_on_running bool) error {
+func (client *Client) UpdateApplication(application *Application, wait_on_running bool) (*Application, error) {
 	result := new(Application)
 	client.log("Updating application: %s", application)
 
 	uri := fmt.Sprintf("%s/%s", MARATHON_API_APPS, trimRootPath(application.ID))
 
 	if err := client.apiPut(uri, &application, result); err != nil {
-		return err
+		return nil, err
 	}
 	// step: are we waiting for the application to start?
 	if wait_on_running {
-		return client.WaitOnApplication(application.ID, 0)
+		return nil, client.WaitOnApplication(application.ID, 0)
 	}
-	return nil
+	return result, nil
 }

--- a/application_test.go
+++ b/application_test.go
@@ -20,6 +20,17 @@ import (
 	"testing"
 )
 
+func TestCreateApplication(t *testing.T) {
+	client := NewFakeMarathonEndpoint(t)
+	application := NewDockerApplication()
+	application.ID = "/fake_app"
+	app, err := client.CreateApplication(application, false)
+	assertOnError(err, t)
+	assertOnNull(app, t)
+	assertOnString(application.ID, "/fake_app", t)
+	assertOnString(app.DeploymentID[0]["id"], "f44fd4fc-4330-4600-a68b-99c7bd33014a", t)
+}
+
 func TestApplications(t *testing.T) {
 	client := NewFakeMarathonEndpoint(t)
 	applications, err := client.Applications(nil)

--- a/client.go
+++ b/client.go
@@ -53,11 +53,11 @@ type Marathon interface {
 	/* check if an application is ok */
 	ApplicationOK(name string) (bool, error)
 	/* create an application in marathon */
-	CreateApplication(application *Application, wait_on_running bool) error
+	CreateApplication(application *Application, wait_on_running bool) (*Application, error)
 	/* delete an application */
 	DeleteApplication(name string) (*DeploymentID, error)
 	/* update an application in marathon */
-	UpdateApplication(application *Application, wait_on_running bool) error
+	UpdateApplication(application *Application, wait_on_running bool) (*Application, error)
 	/* a list of deployments on a application */
 	ApplicationDeployments(name string) ([]*DeploymentID, error)
 	/* scale a application */

--- a/examples/applications/main.go
+++ b/examples/applications/main.go
@@ -84,7 +84,8 @@ func main() {
 	application.AddEnv("SERVICE_80_NAME", "test_http")
 	application.RequirePorts = true
 	application.Container.Docker.Container("quay.io/gambol99/apache-php:latest").Expose(80).Expose(443)
-	Assert(client.CreateApplication(application, true))
+	err, _ = client.CreateApplication(application, true)
+	Assert(err)
 
 	glog.Infof("Scaling the application to 4 instances")
 	deployId, err := client.ScaleApplicationInstances(application.ID, 4)
@@ -99,7 +100,8 @@ func main() {
 	glog.Infof("Successfully deleted the application")
 
 	glog.Infof("Starting the application again")
-	Assert(client.CreateApplication(application, true))
+	err, _ = client.CreateApplication(application, true)
+	Assert(err)
 	glog.Infof("Created the application: %s", application.ID)
 
 	glog.Infof("Delete all the tasks")

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -21,54 +21,61 @@
   method: POST
   content: |
     {
-    "args": null,
-    "backoffFactor": 1.15,
-    "backoffSeconds": 1,
-    "cmd": "env && python3 -m http.server $PORT0",
-    "constraints": [
-        [
-            "hostname",
-            "UNIQUE"
-        ]
-    ],
-    "container": {
-        "docker": {
-            "image": "python:3"
-        },
-        "type": "DOCKER",
-        "volumes": []
-    },
-    "cpus": 0.25,
-    "dependencies": [],
-    "disk": 0.0,
-    "env": {},
-    "executor": "",
-    "healthChecks": [
-        {
-            "command": null,
-            "gracePeriodSeconds": 3,
-            "intervalSeconds": 10,
-            "maxConsecutiveFailures": 3,
-            "path": "/",
-            "portIndex": 0,
-            "protocol": "HTTP",
-            "timeoutSeconds": 5
-        }
-    ],
-    "id": "/my-app",
-    "instances": 2,
-    "mem": 50.0,
-    "ports": [
-        0
-    ],
-    "requirePorts": false,
-    "storeUrls": [],
-    "upgradeStrategy": {
-        "minimumHealthCapacity": 0.5
-    },
-    "uris": [],
-    "user": null,
-    "version": "2014-08-18T22:36:41.451Z"
+      "args": null,
+      "backoffFactor": 1.15,
+      "backoffSeconds": 1,
+      "maxLaunchDelaySeconds": 3600,
+      "cmd": "env && python3 -m http.server $PORT0",
+      "constraints": [
+          [
+              "hostname",
+              "UNIQUE"
+          ]
+      ],
+      "container": {
+          "docker": {
+              "image": "python:3"
+          },
+          "type": "DOCKER",
+          "volumes": []
+      },
+      "cpus": 0.25,
+      "dependencies": [],
+      "deployments": [
+          {
+              "id": "f44fd4fc-4330-4600-a68b-99c7bd33014a"
+          }
+      ],
+      "disk": 0.0,
+      "env": {},
+      "executor": "",
+      "healthChecks": [
+          {
+              "command": null,
+              "gracePeriodSeconds": 3,
+              "intervalSeconds": 10,
+              "maxConsecutiveFailures": 3,
+              "path": "/",
+              "portIndex": 0,
+              "protocol": "HTTP",
+              "timeoutSeconds": 5
+          }
+      ],
+      "id": "/fake_app",
+      "instances": 2,
+      "mem": 50.0,
+      "ports": [
+          0
+      ],
+      "requirePorts": false,
+      "storeUrls": [],
+      "upgradeStrategy": {
+          "minimumHealthCapacity": 0.5,
+          "maximumOverCapacity": 0.5
+      },
+      "uris": [],
+      "user": null,
+      "version": "2014-08-18T22:36:41.451Z"
     }
 - uri: /v2/apps
   method: GET


### PR DESCRIPTION
Returning the deployment ids from the Create and Update methods ... make sense, as the results are already being decoded just for *some reason* not being handed back