### PR TITLE
Fix typo in app struct tag.

### DIFF
--- a/application.go
+++ b/application.go
@@ -38,7 +38,7 @@ type ApplicationWrap struct {
 }
 
 type Application struct {
-	ID                    string              `json:"id",omitempty`
+	ID                    string              `json:"id,omitempty"`
 	Cmd                   string              `json:"cmd,omitempty"`
 	Args                  []string            `json:"args,omitempty"`
 	Constraints           [][]string          `json:"constraints,omitempty"`


### PR DESCRIPTION
Fixes typo in `Application.ID` field tag.