### PR TITLE
UpdateApplication returns DeploymentID.

### DIFF
--- a/application.go
+++ b/application.go
@@ -506,11 +506,11 @@ func (r *marathonClient) ScaleApplicationInstances(name string, instances int, f
 	return deployID, nil
 }
 
-// UpdateApplication updates a new application in Marathon
-// 		application: 		the structure holding the application configuration
-//		wait_on_running:	waits on the application deploying, i.e. the instances arre all running (note health checks are excluded)
-func (r *marathonClient) UpdateApplication(application *Application, waitOnRunning bool) (*Application, error) {
-	result := new(Application)
+// UpdateApplication updates an application in Marathon
+// 		application:		the structure holding the application configuration
+//		waitOnrunning:		waits on the application deploying, i.e. the instances are all running (note health checks are excluded)
+func (r *marathonClient) UpdateApplication(application *Application, waitOnRunning bool) (*DeploymentID, error) {
+	result := new(DeploymentID)
 	glog.V(DEBUG_LEVEL).Infof("updating application: %s, waitOnRunning: %t", application, waitOnRunning)
 
 	uri := fmt.Sprintf("%s/%s", MARATHON_API_APPS, trimRootPath(application.ID))
@@ -520,7 +520,7 @@ func (r *marathonClient) UpdateApplication(application *Application, waitOnRunni
 	}
 	// step: are we waiting for the application to start?
 	if waitOnRunning {
-		return nil, r.WaitOnApplication(application.ID, 0)
+		return result, r.WaitOnApplication(application.ID, 0)
 	}
 	return result, nil
 }

--- a/application_test.go
+++ b/application_test.go
@@ -139,6 +139,16 @@ func TestCreateApplication(t *testing.T) {
 	assert.Equal(t, app.DeploymentID[0]["id"], "f44fd4fc-4330-4600-a68b-99c7bd33014a")
 }
 
+func TestUpdateApplication(t *testing.T) {
+	client := NewFakeMarathonEndpoint(t)
+	application := NewDockerApplication()
+	application.ID = "/fake_app"
+	id, err := client.UpdateApplication(application, false)
+	assert.Nil(t, err)
+	assert.Equal(t, id.DeploymentID, "83b215a6-4e26-4e44-9333-5c385eda6438")
+	assert.Equal(t, id.Version, "2014-08-26T07:37:50.462Z")
+}
+
 func TestApplications(t *testing.T) {
 	client := NewFakeMarathonEndpoint(t)
 	applications, err := client.Applications(nil)

--- a/client.go
+++ b/client.go
@@ -53,7 +53,7 @@ type Marathon interface {
 	// delete an application
 	DeleteApplication(name string) (*DeploymentID, error)
 	// update an application in marathon
-	UpdateApplication(application *Application, waitOnRunning bool) (*Application, error)
+	UpdateApplication(application *Application, waitOnRunning bool) (*DeploymentID, error)
 	// a list of deployments on a application
 	ApplicationDeployments(name string) ([]*DeploymentID, error)
 	// scale a application

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -10,13 +10,6 @@
             "2014-04-04T06:25:31.399Z"
         ]
     }
-- uri: /v2/apps/fake_app
-  method: PUT
-  content: |
-    {
-        "deploymentId": "83b215a6-4e26-4e44-9333-5c385eda6438",
-        "version": "2014-04-04T06:25:31.399Z"
-    }
 - uri: /v2/apps
   method: POST
   content: |


### PR DESCRIPTION
According to https://mesosphere.github.io/marathon/docs/rest-api.html#put-v2-apps-appid marathon returns deployment information after updating an app.

Additionally, duplicate `put` endpoint was removed from `methods.yml`.