### PR TITLE
Remove waitOnRunning argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ application.AddEnv("SERVICE_80_NAME", "test_http")
 application.Container.Docker.Container("quay.io/gambol99/apache-php:latest").Expose(80).Expose(443)
 application.CheckHTTP("/health", 10, 5)
 
-if _, err := client.CreateApplication(application, true); err != nil {
+if _, err := client.CreateApplication(application); err != nil {
 	glog.Errorf("Failed to create application: %s, error: %s", application, err)
 } else {
 	glog.Infof("Created the application: %s", application)
@@ -100,7 +100,7 @@ glog.Infof("Scale to 4 instances")
 if err := client.ScaleApplicationInstances(application.ID, 10); err != nil {
 	glog.Errorf("Failed to delete the application: %s, error: %s", application, err)
 } else {
-	client.WaitOnApplication(application.ID, 0)
+	client.WaitOnApplication(application.ID, 30 * time.Second)
 	glog.Infof("Successfully scaled the application")
 }
 ```

--- a/application_test.go
+++ b/application_test.go
@@ -132,7 +132,7 @@ func TestCreateApplication(t *testing.T) {
 	client := NewFakeMarathonEndpoint(t)
 	application := NewDockerApplication()
 	application.ID = "/fake_app"
-	app, err := client.CreateApplication(application, false)
+	app, err := client.CreateApplication(application)
 	assert.Nil(t, err)
 	assert.NotNil(t, app)
 	assert.Equal(t, application.ID, "/fake_app")
@@ -143,7 +143,7 @@ func TestUpdateApplication(t *testing.T) {
 	client := NewFakeMarathonEndpoint(t)
 	application := NewDockerApplication()
 	application.ID = "/fake_app"
-	id, err := client.UpdateApplication(application, false)
+	id, err := client.UpdateApplication(application)
 	assert.Nil(t, err)
 	assert.Equal(t, id.DeploymentID, "83b215a6-4e26-4e44-9333-5c385eda6438")
 	assert.Equal(t, id.Version, "2014-08-26T07:37:50.462Z")

--- a/client.go
+++ b/client.go
@@ -49,11 +49,11 @@ type Marathon interface {
 	// check if an application is ok
 	ApplicationOK(name string) (bool, error)
 	// create an application in marathon
-	CreateApplication(application *Application, waitOnRunning bool) (*Application, error)
+	CreateApplication(application *Application) (*Application, error)
 	// delete an application
 	DeleteApplication(name string) (*DeploymentID, error)
 	// update an application in marathon
-	UpdateApplication(application *Application, waitOnRunning bool) (*DeploymentID, error)
+	UpdateApplication(application *Application) (*DeploymentID, error)
 	// a list of deployments on a application
 	ApplicationDeployments(name string) ([]*DeploymentID, error)
 	// scale a application
@@ -91,7 +91,7 @@ type Marathon interface {
 	// retrieve a specific group from marathon
 	Group(name string) (*Group, error)
 	// create a group deployment
-	CreateGroup(group *Group, waitOnRunning bool) error
+	CreateGroup(group *Group) error
 	// delete a group
 	DeleteGroup(name string) (*DeploymentID, error)
 	// update a groups

--- a/config.go
+++ b/config.go
@@ -19,7 +19,6 @@ package marathon
 import (
 	"io"
 	"io/ioutil"
-	"time"
 )
 
 // Config hold the setting and options for the client
@@ -34,8 +33,6 @@ type Config struct {
 	LogOutput io.Writer
 	// the timeout for requests
 	RequestTimeout int
-	// the default timeout for deployments
-	DefaultDeploymentTimeout time.Duration
 	// http basic auth
 	HttpBasicAuthUser string
 	// http basic password
@@ -45,12 +42,11 @@ type Config struct {
 // NewDefaultConfig create a default client config
 func NewDefaultConfig() Config {
 	return Config{
-		URL:                      "http://127.0.0.1:8080",
-		EventsPort:               10001,
-		EventsInterface:          "eth0",
-		LogOutput:                ioutil.Discard,
-		HttpBasicAuthUser:        "",
-		HttpBasicPassword:        "",
-		DefaultDeploymentTimeout: time.Duration(300) * time.Second,
-		RequestTimeout:           5}
+		URL:               "http://127.0.0.1:8080",
+		EventsPort:        10001,
+		EventsInterface:   "eth0",
+		LogOutput:         ioutil.Discard,
+		HttpBasicAuthUser: "",
+		HttpBasicPassword: "",
+		RequestTimeout:    5}
 }

--- a/examples/applications/main.go
+++ b/examples/applications/main.go
@@ -84,13 +84,13 @@ func main() {
 	application.AddEnv("SERVICE_80_NAME", "test_http")
 	application.RequirePorts = true
 	application.Container.Docker.Container("quay.io/gambol99/apache-php:latest").Expose(80).Expose(443)
-	_, err = client.CreateApplication(application, true)
+	_, err = client.CreateApplication(application)
 	Assert(err)
 
 	glog.Infof("Scaling the application to 4 instances")
 	deployId, err := client.ScaleApplicationInstances(application.ID, 4, false)
 	Assert(err)
-	client.WaitOnApplication(application.ID, 0)
+	client.WaitOnApplication(application.ID, 30*time.Second)
 	glog.Infof("Successfully scaled the application, deployId: %s", deployId.DeploymentID)
 
 	glog.Infof("Deleting the application: %s", APPLICATION_NAME)
@@ -100,7 +100,7 @@ func main() {
 	glog.Infof("Successfully deleted the application")
 
 	glog.Infof("Starting the application again")
-	_, err = client.CreateApplication(application, true)
+	_, err = client.CreateApplication(application)
 	Assert(err)
 	glog.Infof("Created the application: %s", application.ID)
 

--- a/examples/groups/main.go
+++ b/examples/groups/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	marathon "github.com/gambol99/go-marathon"
 	"github.com/golang/glog"
@@ -105,7 +106,7 @@ func main() {
 	group := marathon.NewApplicationGroup(GROUP_NAME)
 	group.App(frontend).App(redis).App(mysql)
 
-	Assert(client.CreateGroup(group, true))
+	Assert(client.CreateGroup(group))
 	glog.Infof("Successfully created the group: %s", group.ID)
 
 	glog.Infof("Updating the group paramaters")
@@ -114,5 +115,5 @@ func main() {
 	id, err := client.UpdateGroup(GROUP_NAME, group)
 	Assert(err)
 	glog.Infof("Successfully updated the group: %s, version: %s", group.ID, id.DeploymentID)
-	Assert(client.WaitOnGroup(GROUP_NAME, 0))
+	Assert(client.WaitOnGroup(GROUP_NAME, 500*time.Second))
 }

--- a/group.go
+++ b/group.go
@@ -101,23 +101,14 @@ func (r *marathonClient) HasGroup(name string) (bool, error) {
 
 // CreateGroup creates a new group in marathon
 //		group:			a pointer the Group structure defining the group
-func (r *marathonClient) CreateGroup(group *Group, waitOnRunning bool) error {
-	if err := r.apiPost(MARATHON_API_GROUPS, group, nil); err != nil {
-		return err
-	}
-	if waitOnRunning {
-		return r.WaitOnGroup(group.ID, 0)
-	}
-	return nil
+func (r *marathonClient) CreateGroup(group *Group) error {
+	return r.apiPost(MARATHON_API_GROUPS, group, nil)
 }
 
 // WaitOnGroup waits for all the applications in a group to be deployed
 // 		group:			the identifier for the group
 //		timeout: 		a duration of time to wait before considering it failed (all tasks in all apps running defined as deployed)
 func (r *marathonClient) WaitOnGroup(name string, timeout time.Duration) error {
-	if timeout <= 0 {
-		timeout = time.Duration(500) * time.Second
-	}
 	err := deadline(timeout, func(stop_channel chan bool) error {
 		var flick atomicSwitch
 		go func() {


### PR DESCRIPTION
Follow up of https://github.com/gambol99/go-marathon/pull/69#issuecomment-149003045

- Instead of passing boolean argument the WaitOnApplication or
  WaitOnGroup method should be used

- Removed the default timeout from config since the timeout is always
  specified now