### PR TITLE
Remove some omitempty

### DIFF
--- a/application.go
+++ b/application.go
@@ -39,14 +39,14 @@ type Applications struct {
 type Application struct {
 	ID                    string              `json:"id,omitempty"`
 	Cmd                   string              `json:"cmd,omitempty"`
-	Args                  []string            `json:"args,omitempty"`
-	Constraints           [][]string          `json:"constraints,omitempty"`
+	Args                  []string            `json:"args"`
+	Constraints           [][]string          `json:"constraints"`
 	Container             *Container          `json:"container,omitempty"`
 	CPUs                  float64             `json:"cpus,omitempty"`
 	Disk                  float64             `json:"disk,omitempty"`
-	Env                   map[string]string   `json:"env,omitempty"`
+	Env                   map[string]string   `json:"env"`
 	Executor              string              `json:"executor,omitempty"`
-	HealthChecks          []*HealthCheck      `json:"healthChecks,omitempty"`
+	HealthChecks          []*HealthCheck      `json:"healthChecks"`
 	Instances             int                 `json:"instances,omitempty"`
 	Mem                   float64             `json:"mem,omitempty"`
 	Tasks                 []*Task             `json:"tasks,omitempty"`
@@ -56,14 +56,14 @@ type Application struct {
 	BackoffFactor         float64             `json:"backoffFactor,omitempty"`
 	MaxLaunchDelaySeconds float64             `json:"maxLaunchDelaySeconds,omitempty"`
 	DeploymentID          []map[string]string `json:"deployments,omitempty"`
-	Dependencies          []string            `json:"dependencies,omitempty"`
+	Dependencies          []string            `json:"dependencies"`
 	TasksRunning          int                 `json:"tasksRunning,omitempty"`
 	TasksStaged           int                 `json:"tasksStaged,omitempty"`
 	TasksHealthy          int                 `json:"tasksHealthy,omitempty"`
 	TasksUnhealthy        int                 `json:"tasksUnhealthy,omitempty"`
 	User                  string              `json:"user,omitempty"`
 	UpgradeStrategy       *UpgradeStrategy    `json:"upgradeStrategy,omitempty"`
-	Uris                  []string            `json:"uris,omitempty"`
+	Uris                  []string            `json:"uris"`
 	Version               string              `json:"version,omitempty"`
 	VersionInfo           *VersionInfo        `json:"versionInfo,omitempty"`
 	Labels                map[string]string   `json:"labels,omitempty"`

--- a/health.go
+++ b/health.go
@@ -24,7 +24,7 @@ type HealthCheck struct {
 	GracePeriodSeconds     int      `json:"gracePeriodSeconds,omitempty"`
 	IntervalSeconds        int      `json:"intervalSeconds,omitempty"`
 	PortIndex              int      `json:"portIndex,omitempty"`
-	MaxConsecutiveFailures int      `json:"maxConsecutiveFailures,omitempty"`
+	MaxConsecutiveFailures int      `json:"maxConsecutiveFailures"`
 	TimeoutSeconds         int      `json:"timeoutSeconds,omitempty"`
 }
 


### PR DESCRIPTION
I ran into a few of these when I was trying to update an marathon app's attributes to empty. With the `omitempty`, if they're empty, they do not get sent. So removing that fixed it. Also, I removed the `omitempty` on the `MaxConsecutiveFailures` as 0 is a valid option (marathon then doesn't stop the task).