### PR TITLE
Deployments confusion

### DIFF
--- a/application.go
+++ b/application.go
@@ -55,7 +55,7 @@ type Application struct {
 	BackoffSeconds        float64             `json:"backoffSeconds,omitempty"`
 	BackoffFactor         float64             `json:"backoffFactor,omitempty"`
 	MaxLaunchDelaySeconds float64             `json:"maxLaunchDelaySeconds,omitempty"`
-	DeploymentID          []map[string]string `json:"deployments,omitempty"`
+	Deployments           []map[string]string `json:"deployments,omitempty"`
 	Dependencies          []string            `json:"dependencies"`
 	TasksRunning          int                 `json:"tasksRunning,omitempty"`
 	TasksStaged           int                 `json:"tasksStaged,omitempty"`
@@ -191,13 +191,13 @@ func (r *Application) HasHealthChecks() bool {
 }
 
 // Deployments retrieves the application deployments ID
-func (r *Application) Deployments() []*DeploymentID {
+func (r *Application) DeploymentIDs() []*DeploymentID {
 	var deployments []*DeploymentID
-	if r.DeploymentID == nil || len(r.DeploymentID) <= 0 {
+	if r.Deployments == nil || len(r.Deployments) <= 0 {
 		return deployments
 	}
 	// step: extract the deployment id from the result
-	for _, deploy := range r.DeploymentID {
+	for _, deploy := range r.Deployments {
 		if id, found := deploy["id"]; found {
 			deployment := &DeploymentID{
 				Version:      r.Version,
@@ -390,7 +390,7 @@ func (r *marathonClient) ApplicationDeployments(name string) ([]*DeploymentID, e
 		return nil, err
 	}
 
-	return application.Deployments(), nil
+	return application.DeploymentIDs(), nil
 }
 
 // CreateApplication creates a new application in Marathon

--- a/application.go
+++ b/application.go
@@ -190,7 +190,7 @@ func (r *Application) HasHealthChecks() bool {
 	return false
 }
 
-// Deployments retrieves the application deployments ID
+// DeploymentIDs retrieves the application deployments IDs
 func (r *Application) DeploymentIDs() []*DeploymentID {
 	var deployments []*DeploymentID
 	if r.Deployments == nil || len(r.Deployments) <= 0 {

--- a/application.go
+++ b/application.go
@@ -39,14 +39,14 @@ type Applications struct {
 type Application struct {
 	ID                    string              `json:"id,omitempty"`
 	Cmd                   string              `json:"cmd,omitempty"`
-	Args                  []string            `json:"args,omitempty"`
-	Constraints           [][]string          `json:"constraints,omitempty"`
+	Args                  []string            `json:"args"`
+	Constraints           [][]string          `json:"constraints"`
 	Container             *Container          `json:"container,omitempty"`
 	CPUs                  float64             `json:"cpus,omitempty"`
 	Disk                  float64             `json:"disk,omitempty"`
-	Env                   map[string]string   `json:"env,omitempty"`
+	Env                   map[string]string   `json:"env"`
 	Executor              string              `json:"executor,omitempty"`
-	HealthChecks          []*HealthCheck      `json:"healthChecks,omitempty"`
+	HealthChecks          []*HealthCheck      `json:"healthChecks"`
 	Instances             int                 `json:"instances,omitempty"`
 	Mem                   float64             `json:"mem,omitempty"`
 	Tasks                 []*Task             `json:"tasks,omitempty"`
@@ -56,14 +56,14 @@ type Application struct {
 	BackoffFactor         float64             `json:"backoffFactor,omitempty"`
 	MaxLaunchDelaySeconds float64             `json:"maxLaunchDelaySeconds,omitempty"`
 	DeploymentID          []map[string]string `json:"deployments,omitempty"`
-	Dependencies          []string            `json:"dependencies,omitempty"`
+	Dependencies          []string            `json:"dependencies"`
 	TasksRunning          int                 `json:"tasksRunning,omitempty"`
 	TasksStaged           int                 `json:"tasksStaged,omitempty"`
 	TasksHealthy          int                 `json:"tasksHealthy,omitempty"`
 	TasksUnhealthy        int                 `json:"tasksUnhealthy,omitempty"`
 	User                  string              `json:"user,omitempty"`
 	UpgradeStrategy       *UpgradeStrategy    `json:"upgradeStrategy,omitempty"`
-	Uris                  []string            `json:"uris,omitempty"`
+	Uris                  []string            `json:"uris"`
 	Version               string              `json:"version,omitempty"`
 	VersionInfo           *VersionInfo        `json:"versionInfo,omitempty"`
 	Labels                map[string]string   `json:"labels,omitempty"`

--- a/application_test.go
+++ b/application_test.go
@@ -136,7 +136,7 @@ func TestCreateApplication(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, app)
 	assert.Equal(t, application.ID, "/fake_app")
-	assert.Equal(t, app.DeploymentID[0]["id"], "f44fd4fc-4330-4600-a68b-99c7bd33014a")
+	assert.Equal(t, app.Deployments[0]["id"], "f44fd4fc-4330-4600-a68b-99c7bd33014a")
 }
 
 func TestUpdateApplication(t *testing.T) {

--- a/client.go
+++ b/client.go
@@ -110,7 +110,7 @@ type Marathon interface {
 	// check to see if a deployment exists
 	HasDeployment(id string) (bool, error)
 	// wait of a deployment to finish
-	WaitOnDeployment(version string, timeout time.Duration) error
+	WaitOnDeployment(id string, timeout time.Duration) error
 
 	// --- SUBSCRIPTIONS ---
 

--- a/group.go
+++ b/group.go
@@ -139,7 +139,7 @@ func (r *marathonClient) WaitOnGroup(name string, timeout time.Duration) error {
 						allRunning = false
 					} else if application.TasksRunning != appID.Instances {
 						allRunning = false
-					} else if len(application.Deployments()) > 0 {
+					} else if len(application.DeploymentIDs()) > 0 {
 						allRunning = false
 					}
 				}

--- a/health.go
+++ b/health.go
@@ -24,7 +24,7 @@ type HealthCheck struct {
 	GracePeriodSeconds     int      `json:"gracePeriodSeconds,omitempty"`
 	IntervalSeconds        int      `json:"intervalSeconds,omitempty"`
 	PortIndex              int      `json:"portIndex,omitempty"`
-	MaxConsecutiveFailures int      `json:"maxConsecutiveFailures,omitempty"`
+	MaxConsecutiveFailures int      `json:"maxConsecutiveFailures"`
 	TimeoutSeconds         int      `json:"timeoutSeconds,omitempty"`
 }
 


### PR DESCRIPTION
This clears up `Deployments` and `DeploymentIDs` on the application. `Deployments` now matches what the JSON says and `app.DeploymentIDs()` is a nice wrapper around that.

This one builds on #71 as otherwise they'll conflict.