### PR TITLE
Adds customisable CallbackUrl

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	HttpBasicAuthUser string
 	// http basic password
 	HttpBasicPassword string
+	// custom callback url
+	CallbackUrl string
 }
 
 // NewDefaultConfig create a default client config
@@ -48,5 +50,6 @@ func NewDefaultConfig() Config {
 		LogOutput:         ioutil.Discard,
 		HttpBasicAuthUser: "",
 		HttpBasicPassword: "",
-		RequestTimeout:    5}
+		RequestTimeout:    5,
+		CallbackUrl:       ""}
 }

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	// http basic password
 	HttpBasicPassword string
 	// custom callback url
-	CallbackUrl string
+	CallbackURL string
 }
 
 // NewDefaultConfig create a default client config
@@ -51,5 +51,5 @@ func NewDefaultConfig() Config {
 		HttpBasicAuthUser: "",
 		HttpBasicPassword: "",
 		RequestTimeout:    5,
-		CallbackUrl:       ""}
+		CallbackURL:       ""}
 }

--- a/subscription.go
+++ b/subscription.go
@@ -78,6 +78,10 @@ func (r *marathonClient) RemoveEventsListener(channel EventsChannel) {
 
 // SubscriptionURL retrieves the subscription call back URL used when registering
 func (r *marathonClient) SubscriptionURL() string {
+	if r.config.CallbackUrl != "" {
+		return fmt.Sprintf("%s%s", r.config.CallbackUrl, DEFAULT_EVENTS_URL)
+	}
+
 	return fmt.Sprintf("http://%s:%d%s", r.ipAddress, r.config.EventsPort, DEFAULT_EVENTS_URL)
 }
 

--- a/subscription.go
+++ b/subscription.go
@@ -78,8 +78,8 @@ func (r *marathonClient) RemoveEventsListener(channel EventsChannel) {
 
 // SubscriptionURL retrieves the subscription call back URL used when registering
 func (r *marathonClient) SubscriptionURL() string {
-	if r.config.CallbackUrl != "" {
-		return fmt.Sprintf("%s%s", r.config.CallbackUrl, DEFAULT_EVENTS_URL)
+	if r.config.CallbackURL != "" {
+		return fmt.Sprintf("%s%s", r.config.CallbackURL, DEFAULT_EVENTS_URL)
 	}
 
 	return fmt.Sprintf("http://%s:%d%s", r.ipAddress, r.config.EventsPort, DEFAULT_EVENTS_URL)


### PR DESCRIPTION
Solves issue where the library is run within a Docker container.

When inside of a container, it will attempt to (correct) bind to the eth0 interface on the docker0 bridge (172.16.0.0/16). This will result in a non routable callback url being sent to Marathon. This change gives user the ability to specify a custom endpoint, failing back to the original method.