### PR TITLE
upgradeStrategy params not omitempty for 0 values

### DIFF
--- a/update_strategy.go
+++ b/update_strategy.go
@@ -18,6 +18,6 @@ package marathon
 
 // UpgradeStrategy is upgrade strategy applied to a application
 type UpgradeStrategy struct {
-	MinimumHealthCapacity float64 `json:"minimumHealthCapacity,omitempty"`
-	MaximumOverCapacity   float64 `json:"maximumOverCapacity,omitempty"`
+	MinimumHealthCapacity float64 `json:"minimumHealthCapacity"`
+	MaximumOverCapacity   float64 `json:"maximumOverCapacity"`
 }


### PR DESCRIPTION
This will allow these to have 0.0 for values.