### PR TITLE
Fix typo in application.go (marathin -> marathon).

### DIFF
--- a/application.go
+++ b/application.go
@@ -71,7 +71,7 @@ type Application struct {
 	LastTaskFailure       *LastTaskFailure    `json:"lastTaskFailure,omitempty"`
 }
 
-// ApplicationVersions is a collection of application versions for a specific app in marathin
+// ApplicationVersions is a collection of application versions for a specific app in marathon
 type ApplicationVersions struct {
 	Versions []string `json:"versions"`
 }


### PR DESCRIPTION
Super unspectacular PR that fixes a tiny typo in application.go.