### PR TITLE
Make Application.{Arg,DependsOn}, Docker.Expose* variadic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ glog.Infof("Deploying a new application")
 application := marathon.NewDockerApplication()
 application.Name("/product/name/frontend")
 application.CPU(0.1).Memory(64).Storage(0.0).Count(2)
-application.Arg("/usr/sbin/apache2ctl").Arg("-D").Arg("FOREGROUND")
+application.Arg("/usr/sbin/apache2ctl", "-D", "FOREGROUND")
 application.AddEnv("NAME", "frontend_http")
 application.AddEnv("SERVICE_80_NAME", "test_http")
 // add the docker container
-application.Container.Docker.Container("quay.io/gambol99/apache-php:latest").Expose(80).Expose(443)
+application.Container.Docker.Container("quay.io/gambol99/apache-php:latest").Expose(80, 443)
 application.CheckHTTP("/health", 10, 5)
 
 if _, err := client.CreateApplication(application); err != nil {

--- a/application.go
+++ b/application.go
@@ -130,15 +130,15 @@ func (r *Application) AllTaskRunning() bool {
 	return false
 }
 
-// DependsOn adds a dependency for this application. Note, if you want to wait for an application
-// dependency to actually be UP, i.e. not just deployed, you need a health check on the
-// dependant app.
-//		name:	the application id which this application depends on
-func (r *Application) DependsOn(name string) *Application {
+// DependsOn adds one or more dependencies for this application. Note, if you want to wait for
+// an application dependency to actually be UP, i.e. not just deployed, you need a health check
+// on the dependant app.
+//		names:	the application id(s) this application depends on
+func (r *Application) DependsOn(names ...string) *Application {
 	if r.Dependencies == nil {
 		r.Dependencies = make([]string, 0)
 	}
-	r.Dependencies = append(r.Dependencies, name)
+	r.Dependencies = append(r.Dependencies, names...)
 
 	return r
 }
@@ -159,13 +159,13 @@ func (r *Application) Count(count int) *Application {
 	return r
 }
 
-// Arg adds an argument to the applications
-//		argument:	the argument you are adding
-func (r *Application) Arg(argument string) *Application {
+// Arg adds one or more arguments to the applications
+//		arguments:	the argument(s) you are adding
+func (r *Application) Arg(arguments ...string) *Application {
 	if r.Args == nil {
 		r.Args = make([]string, 0)
 	}
-	r.Args = append(r.Args, argument)
+	r.Args = append(r.Args, arguments...)
 
 	return r
 }

--- a/application_test.go
+++ b/application_test.go
@@ -25,8 +25,8 @@ import (
 func TestApplicationDependsOn(t *testing.T) {
 	app := NewDockerApplication()
 	app.DependsOn("fake_app")
-	app.DependsOn("fake_app1")
-	assert.Equal(t, 2, len(app.Dependencies))
+	app.DependsOn("fake_app1", "fake_app2")
+	assert.Equal(t, 3, len(app.Dependencies))
 }
 
 func TestApplicationMemory(t *testing.T) {
@@ -66,7 +66,7 @@ func TestApplicationCPU(t *testing.T) {
 func TestApplicationArgs(t *testing.T) {
 	app := NewDockerApplication()
 	assert.Equal(t, 0, len(app.Args))
-	app.Arg("-p").Arg("option").Arg("-v")
+	app.Arg("-p").Arg("option", "-v")
 	assert.Equal(t, 3, len(app.Args))
 	assert.Equal(t, "-p", app.Args[0])
 	assert.Equal(t, "option", app.Args[1])

--- a/docker.go
+++ b/docker.go
@@ -102,17 +102,21 @@ func (docker *Docker) Bridged() *Docker {
 	return docker
 }
 
-// Expose sets the container to expose the following port
-//		port:			the port the container is exposing
-func (docker *Docker) Expose(port int) *Docker {
-	docker.ExposePort(port, 0, 0, "tcp")
+// Expose sets the container to expose the following TCP ports
+//		ports:			the TCP ports the container is exposing
+func (docker *Docker) Expose(ports ...int) *Docker {
+	for _, port := range ports {
+		docker.ExposePort(port, 0, 0, "tcp")
+	}
 	return docker
 }
 
-// ExposeUDP sets the container to expose the following UDP port
-//		port:			the port the container is exposing
-func (docker *Docker) ExposeUDP(port int) *Docker {
-	docker.ExposePort(port, 0, 0, "udp")
+// ExposeUDP sets the container to expose the following UDP ports
+//		ports:			the UDP ports the container is exposing
+func (docker *Docker) ExposeUDP(ports ...int) *Docker {
+	for _, port := range ports {
+		docker.ExposePort(port, 0, 0, "udp")
+	}
 	return docker
 }
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2015 Rohith All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createPortMapping(containerPort int, protocol string) *PortMapping {
+	return &PortMapping{
+		ContainerPort: containerPort,
+		HostPort:      0,
+		ServicePort:   0,
+		Protocol:      protocol,
+	}
+}
+
+func TestDockerExpose(t *testing.T) {
+	app := NewDockerApplication()
+	app.Container.Docker.Expose(8080).Expose(80, 443)
+
+	portMappings := app.Container.Docker.PortMappings
+	assert.Equal(t, 3, len(portMappings))
+	assert.Equal(t, createPortMapping(8080, "tcp"), portMappings[0])
+	assert.Equal(t, createPortMapping(80, "tcp"), portMappings[1])
+	assert.Equal(t, createPortMapping(443, "tcp"), portMappings[2])
+}
+
+func TestDockerExposeUDP(t *testing.T) {
+	app := NewDockerApplication()
+	app.Container.Docker.ExposeUDP(53).ExposeUDP(5060, 6881)
+
+	portMappings := app.Container.Docker.PortMappings
+	assert.Equal(t, 3, len(portMappings))
+	assert.Equal(t, createPortMapping(53, "udp"), portMappings[0])
+	assert.Equal(t, createPortMapping(5060, "udp"), portMappings[1])
+	assert.Equal(t, createPortMapping(6881, "udp"), portMappings[2])
+}


### PR DESCRIPTION
The following unary functions can be invoked multiple times to
effectively set a collection of values:

- `Application.Arg()`
- `Application.DependsOn()`
- `Docker.Expose()`
- `Docker.ExposeUDP()`

This change makes the before-mentioned functions variadic so that
multiple values can be passed more conveniently.

Note that `Arg()` should actually be called `Args()` now. This requires a
bit more refactoring, however, as the struct receiver the method is
defined on already holds a field by the same name. In order to keep the
change set manageable, we'll leave the task of renaming the method to a
separate PR.