### PR TITLE
Make TestUtilsGetInterfaceAddress platform-independent.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -87,7 +87,7 @@ func getInterfaceAddress(name string) (string, error) {
 			}
 			// step: return the first address
 			if len(addrs) > 0 {
-				return strings.SplitN(addrs[0].String(), "/", 2)[0], nil
+				return parseIPAddr(addrs[0]), nil
 			}
 		}
 	}
@@ -102,4 +102,8 @@ func contains(elements []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func parseIPAddr(addr net.Addr) string {
+	return strings.SplitN(addr.String(), "/", 2)[0]
 }


### PR DESCRIPTION
`TestUtilsGetInterfaceAddress()` in `utils_test.go` relies on the availability of a `lo` interface containing `127.0.0.1` as its first address member. At least on Mac OS X, this does not work because the
localhost device is named `lo0` and first address is the IPv6 one (`::1`).

The existing test is modified to first determine a valid address and subsequently runs the test with the expectation set against the found address. Along the way, we break out and test a helper function needed by both the implementation and the updated `TestUtilsGetInterfaceAddress()` test.