### PR TITLE
Remove Task.String()

### DIFF
--- a/task.go
+++ b/task.go
@@ -41,12 +41,6 @@ type Task struct {
 	Version           string               `json:"version"`
 }
 
-// String returns a string representation of the struct
-func (r Task) String() string {
-	return fmt.Sprintf("id: %s, application: %s, host: %s, ports: %v, created: %s",
-		r.ID, r.AppID, r.Host, r.Ports, r.StartedAt)
-}
-
 // HasHealthCheckResults ... Check if the task has any health checks
 func (r *Task) HasHealthCheckResults() bool {
 	if r.HealthCheckResult == nil || len(r.HealthCheckResult) <= 0 {


### PR DESCRIPTION
Either String() includes all Task fields or we just remove it ;-) I think the latter option just makes it easier to maintain in general. 