### PR TITLE
Remove other email address of mine in AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,7 +11,6 @@ Mikhail Dyakov <wtltl2@gmail.com>
 Nic Grayson <nic.grayson@banno.com>
 Raffaele Di Fazio <raffaele.di.fazio@zalando.de>
 Rohith <gambol99@gmail.com>
-Timo Reimann <devel@foo-lounge.de>
 Timo Reimann <ttr314@googlemail.com>
 Tracy Livengood <tracy.livengood@gmail.com>
 Xavi Ramirez <xavi.ramirez@clever.com>


### PR DESCRIPTION
I must have accidentally been committing with that other Github email of mine. Reducing some noise by removing it.