### PR TITLE
Replaced glog with pkg/log and some housekeeping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@
 #
 language: go
 go:
-  - 1.4
   - 1.5
 install:
   - make test

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It currently supports
 
 Note: the library is still under active development; users should expect frequent (possibly breaking) API changes for the time being.
 
-It requires Go version 1.3 or higher.
+It requires Go version 1.4 or higher.
 
 ## Code Examples
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It currently supports
 
 Note: the library is still under active development; users should expect frequent (possibly breaking) API changes for the time being.
 
-It requires Go version 1.4 or higher.
+It requires Go version 1.5 or higher.
 
 ## Code Examples
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ which is probably the best place to start.
 ```Go
 import (
 	marathon "github.com/gambol99/go-marathon"
-	"github.com/golang/glog"
 )
 
 marathonURL := "http://10.241.1.71:8080"
@@ -33,7 +32,7 @@ config := marathon.NewDefaultConfig()
 config.URL = marathonURL
 client, err := marathon.NewClient(config)
 if err != nil {
-	glog.Fatalf("Failed to create a client for marathon, error: %s", err)
+	log.Fatalf("Failed to create a client for marathon, error: %s", err)
 }
 
 applications, err := client.Applications()
@@ -55,21 +54,21 @@ background process will continue to ping the member until it's back online.
 ```Go
 applications, err := client.Applications()
 if err != nil {
-	glog.Errorf("Failed to list applications")
+	log.Fatalf("Failed to list applications")
 }
 
-glog.Infof("Found %d applications running", len(applications.Apps))
+log.Printf("Found %d applications running", len(applications.Apps))
 for _, application := range applications.Apps {
-	glog.Infof("Application: %s", application)
+	log.Printf("Application: %s", application)
 	details, err := client.Application(application.ID)
 	assert(err)
 	if details.Tasks != nil && len(details.Tasks) > 0 {
 		for _, task := range details.Tasks {
-			glog.Infof("task: %s", task)
+			log.Printf("task: %s", task)
 		}
 		// check the health of the application
 		health, err := client.ApplicationOK(details.ID)
-		glog.Infof("Application: %s, healthy: %t", details.ID, health)
+		log.Printf("Application: %s, healthy: %t", details.ID, health)
 	}
 }
 ```
@@ -77,7 +76,7 @@ for _, application := range applications.Apps {
 ### Creating a new application
 
 ```Go
-glog.Infof("Deploying a new application")
+log.Printf("Deploying a new application")
 application := marathon.NewDockerApplication()
 application.Name("/product/name/frontend")
 application.CPU(0.1).Memory(64).Storage(0.0).Count(2)
@@ -91,9 +90,9 @@ application.Container.Docker.Container("quay.io/gambol99/apache-php:latest").Exp
 application.CheckHTTP("/health", 10, 5)
 
 if _, err := client.CreateApplication(application); err != nil {
-	glog.Errorf("Failed to create application: %s, error: %s", application, err)
+	log.Fatalf("Failed to create application: %s, error: %s", application, err)
 } else {
-	glog.Infof("Created the application: %s", application)
+	log.Printf("Created the application: %s", application)
 }
 ```
 
@@ -104,12 +103,12 @@ Note: Applications may also be defined by means of initializing a `marathon.Appl
 Change the number of application instances to 4
 
 ```Go
-glog.Infof("Scale to 4 instances")
+log.Printf("Scale to 4 instances")
 if err := client.ScaleApplicationInstances(application.ID, 10); err != nil {
-	glog.Errorf("Failed to delete the application: %s, error: %s", application, err)
+	log.Fatalf("Failed to delete the application: %s, error: %s", application, err)
 } else {
 	client.WaitOnApplication(application.ID, 30 * time.Second)
-	glog.Infof("Successfully scaled the application")
+	log.Printf("Successfully scaled the application")
 }
 ```
 
@@ -133,14 +132,14 @@ config.EventsTransport = marathon.EventsTransportSSE
 
 client, err := marathon.NewClient(config)
 if err != nil {
-	glog.Fatalf("Failed to create a client for marathon, error: %s", err)
+	log.Fatalf("Failed to create a client for marathon, error: %s", err)
 }
 
 // Register for events
 events := make(marathon.EventsChannel, 5)
 err = client.AddEventsListener(events, marathon.EVENTS_APPLICATIONS)
 if err != nil {
-	glog.Fatalf("Failed to register for events, %s", err)
+	log.Fatalf("Failed to register for events, %s", err)
 }
 
 timer := time.After(60 * time.Second)
@@ -153,10 +152,10 @@ for {
 	}
 	select {
 	case <-timer:
-		glog.Infof("Exiting the loop")
+		log.Printf("Exiting the loop")
 		done = true
 	case event := <-events:
-		glog.Infof("Recieved event: %s", event)
+		log.Printf("Recieved event: %s", event)
 	}
 }
 
@@ -182,14 +181,14 @@ config.EventsPort = marathonPort
 
 client, err := marathon.NewClient(config)
 if err != nil {
-	glog.Fatalf("Failed to create a client for marathon, error: %s", err)
+	log.Fatalf("Failed to create a client for marathon, error: %s", err)
 }
 
 // Register for events
 events := make(marathon.EventsChannel, 5)
 err = client.AddEventsListener(events, marathon.EVENTS_APPLICATIONS)
 if err != nil {
-	glog.Fatalf("Failed to register for events, %s", err)
+	log.Fatalf("Failed to register for events, %s", err)
 }
 
 timer := time.After(60 * time.Second)
@@ -202,10 +201,10 @@ for {
 	}
 	select {
 	case <-timer:
-		glog.Infof("Exiting the loop")
+		log.Printf("Exiting the loop")
 		done = true
 	case event := <-events:
-		glog.Infof("Recieved event: %s", event)
+		log.Printf("Recieved event: %s", event)
 	}
 }
 

--- a/application.go
+++ b/application.go
@@ -19,7 +19,6 @@ package marathon
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/url"
 	"time"
 )
@@ -479,7 +478,6 @@ func (r *marathonClient) DeleteApplication(name string) (*DeploymentID, error) {
 // RestartApplication performs a rolling restart of marathon application
 // 		name: 		the id used to identify the application
 func (r *marathonClient) RestartApplication(name string, force bool) (*DeploymentID, error) {
-	log.Printf("restarting the application: %s, force: %v", name, force)
 	deployment := new(DeploymentID)
 	var options struct {
 		Force bool `json:"force"`
@@ -497,7 +495,6 @@ func (r *marathonClient) RestartApplication(name string, force bool) (*Deploymen
 // 		instances:	the number of instances you wish to change to
 //    force: used to force the scale operation in case of blocked deployment
 func (r *marathonClient) ScaleApplicationInstances(name string, instances int, force bool) (*DeploymentID, error) {
-	log.Printf("scaling the application: %s, instance: %d", name, instances)
 	changes := new(Application)
 	changes.ID = validateID(name)
 	changes.Instances = instances
@@ -514,13 +511,9 @@ func (r *marathonClient) ScaleApplicationInstances(name string, instances int, f
 // 		application:		the structure holding the application configuration
 func (r *marathonClient) UpdateApplication(application *Application) (*DeploymentID, error) {
 	result := new(DeploymentID)
-	log.Printf("updating application: %v", application)
-
 	uri := fmt.Sprintf("%s/%s", marathonAPIApps, trimRootPath(application.ID))
-
 	if err := r.apiPut(uri, &application, result); err != nil {
 		return nil, err
 	}
-
 	return result, nil
 }

--- a/application.go
+++ b/application.go
@@ -19,10 +19,9 @@ package marathon
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 var (
@@ -480,7 +479,7 @@ func (r *marathonClient) DeleteApplication(name string) (*DeploymentID, error) {
 // RestartApplication performs a rolling restart of marathon application
 // 		name: 		the id used to identify the application
 func (r *marathonClient) RestartApplication(name string, force bool) (*DeploymentID, error) {
-	glog.V(debugLevel).Infof("restarting the application: %s, force: %s", name, force)
+	log.Printf("restarting the application: %s, force: %v", name, force)
 	deployment := new(DeploymentID)
 	var options struct {
 		Force bool `json:"force"`
@@ -498,7 +497,7 @@ func (r *marathonClient) RestartApplication(name string, force bool) (*Deploymen
 // 		instances:	the number of instances you wish to change to
 //    force: used to force the scale operation in case of blocked deployment
 func (r *marathonClient) ScaleApplicationInstances(name string, instances int, force bool) (*DeploymentID, error) {
-	glog.V(debugLevel).Infof("scaling the application: %s, instance: %d", name, instances)
+	log.Printf("scaling the application: %s, instance: %d", name, instances)
 	changes := new(Application)
 	changes.ID = validateID(name)
 	changes.Instances = instances
@@ -515,7 +514,7 @@ func (r *marathonClient) ScaleApplicationInstances(name string, instances int, f
 // 		application:		the structure holding the application configuration
 func (r *marathonClient) UpdateApplication(application *Application) (*DeploymentID, error) {
 	result := new(DeploymentID)
-	glog.V(debugLevel).Infof("updating application: %s", application)
+	log.Printf("updating application: %v", application)
 
 	uri := fmt.Sprintf("%s/%s", marathonAPIApps, trimRootPath(application.ID))
 

--- a/client.go
+++ b/client.go
@@ -305,36 +305,30 @@ func (r *marathonClient) httpRequest(method, uri, body string) (int, string, *ht
 	var content string
 	var response *http.Response
 
-	// Try to connect to Marathon until succeed or
-	// the whole custer is down
-	for {
-		// Get a member from the cluster
-		marathon, err := r.cluster.GetMember()
-		if err != nil {
-			return 0, "", nil, err
-		}
+	// Get a member from the cluster
+	marathon, err := r.cluster.GetMember()
+	if err != nil {
+		return 0, "", nil, err
+	}
 
-		url := fmt.Sprintf("%s/%s", marathon, uri)
+	url := fmt.Sprintf("%s/%s", marathon, uri)
 
-		// Make the http request to Marathon
-		request, err := http.NewRequest(method, url, strings.NewReader(body))
-		if err != nil {
-			return 0, "", nil, err
-		}
+	// Make the http request to Marathon
+	request, err := http.NewRequest(method, url, strings.NewReader(body))
+	if err != nil {
+		return 0, "", nil, err
+	}
 
-		// Add any basic auth and the content headers
-		if r.config.HTTPBasicAuthUser != "" {
-			request.SetBasicAuth(r.config.HTTPBasicAuthUser, r.config.HTTPBasicPassword)
-		}
-		request.Header.Add("Content-Type", "application/json")
-		request.Header.Add("Accept", "application/json")
+	// Add any basic auth and the content headers
+	if r.config.HTTPBasicAuthUser != "" {
+		request.SetBasicAuth(r.config.HTTPBasicAuthUser, r.config.HTTPBasicPassword)
+	}
+	request.Header.Add("Content-Type", "application/json")
+	request.Header.Add("Accept", "application/json")
 
-		response, err = r.httpClient.Do(request)
-		if err == nil {
-			break
-		}
-
-		r.cluster.MarkDown()
+	response, err = r.httpClient.Do(request)
+	if err != nil {
+		return 0, "", nil, err
 	}
 
 	if response.ContentLength != 0 {

--- a/client.go
+++ b/client.go
@@ -28,8 +28,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 // Marathon is the interface to the marathon API
@@ -164,8 +162,6 @@ type marathonClient struct {
 	eventsHTTP *http.Server
 	// the http client use for making requests
 	httpClient *http.Client
-	// the output for the logger
-	logger *log.Logger
 	// the marathon cluster
 	cluster Cluster
 	// a map of service you wish to listen to
@@ -262,18 +258,18 @@ func (r *marathonClient) apiOperation(method, uri string, post, result interface
 }
 
 func (r *marathonClient) apiCall(method, uri, body string, result interface{}) (int, string, error) {
-	glog.V(debugLevel).Infof("[api]: method: %s, uri: %s, body: %s", method, uri, body)
+	log.Printf("[api]: method: %s, uri: %s, body: %s", method, uri, body)
 
 	status, content, _, err := r.httpRequest(method, uri, body)
 	if err != nil {
 		return 0, "", err
 	}
 
-	glog.V(debugLevel).Infof("[api] result: status: %d, content: %s\n", status, content)
+	log.Printf("[api] result: status: %d, content: %s\n", status, content)
 	if status >= 200 && status <= 299 {
 		if result != nil {
 			if err := r.decodeRequest(strings.NewReader(content), result); err != nil {
-				glog.V(debugLevel).Infof("failed to unmarshall the response from marathon, error: %s", err)
+				log.Printf("failed to unmarshall the response from marathon, error: %s", err)
 				return status, content, ErrInvalidResponse
 			}
 		}
@@ -321,7 +317,7 @@ func (r *marathonClient) httpRequest(method, uri, body string) (int, string, *ht
 
 		url := fmt.Sprintf("%s/%s", marathon, uri)
 
-		glog.V(debugLevel).Infof("[http] request: %s, uri: %s, url: %s", method, uri, url)
+		log.Printf("[http] request: %s, uri: %s, url: %s", method, uri, url)
 		// Make the http request to Marathon
 		request, err := http.NewRequest(method, url, strings.NewReader(body))
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -317,7 +317,6 @@ func (r *marathonClient) httpRequest(method, uri, body string) (int, string, *ht
 
 		url := fmt.Sprintf("%s/%s", marathon, uri)
 
-		log.Printf("[http] request: %s, uri: %s, url: %s", method, uri, url)
 		// Make the http request to Marathon
 		request, err := http.NewRequest(method, url, strings.NewReader(body))
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -258,18 +258,17 @@ func (r *marathonClient) apiOperation(method, uri string, post, result interface
 }
 
 func (r *marathonClient) apiCall(method, uri, body string, result interface{}) (int, string, error) {
-	log.Printf("[api]: method: %s, uri: %s, body: %s", method, uri, body)
-
+	log.Printf("apiCall(): request: method: %s, uri: %s, body: %s\n", method, uri, body)
 	status, content, _, err := r.httpRequest(method, uri, body)
 	if err != nil {
 		return 0, "", err
 	}
+	log.Printf("apiCall(): response: status: %d, content: %s\n", status, content)
 
-	log.Printf("[api] result: status: %d, content: %s\n", status, content)
 	if status >= 200 && status <= 299 {
 		if result != nil {
 			if err := r.decodeRequest(strings.NewReader(content), result); err != nil {
-				log.Printf("failed to unmarshall the response from marathon, error: %s", err)
+				log.Printf("apiCall(): failed to unmarshall the response from marathon, error: %s\n", err)
 				return status, content, ErrInvalidResponse
 			}
 		}

--- a/client.go
+++ b/client.go
@@ -265,7 +265,8 @@ func (r *marathonClient) apiCall(method, uri string, body, result interface{}) e
 		log.Printf("apiCall(): %v %v returned %v %s\n", request.Method, request.URL.String(), response.Status, oneLogLine(respBody))
 	}
 
-	if response.StatusCode >= 200 && response.StatusCode <= 299 {
+	switch {
+	case response.StatusCode >= 200 && response.StatusCode <= 299:
 		if result != nil {
 			if err := json.Unmarshal(respBody, result); err != nil {
 				log.Printf("apiCall(): failed to unmarshall the response from marathon, error: %s\n", err)
@@ -274,18 +275,19 @@ func (r *marathonClient) apiCall(method, uri string, body, result interface{}) e
 		}
 		return nil
 
-	} else if response.StatusCode == 404 {
+	case response.StatusCode == 404:
 		return ErrDoesNotExist
 
-	} else if response.StatusCode == 409 {
+	case response.StatusCode == 409:
 		return ErrConflict
 
-	} else if response.StatusCode >= 500 {
+	case response.StatusCode >= 500:
+		return ErrInvalidResponse
+
+	default:
+		log.Printf("apiCall(): unknown error: %s", oneLogLine(respBody))
 		return ErrInvalidResponse
 	}
-
-	log.Printf("apiCall(): unknown error: %s", oneLogLine(respBody))
-	return ErrInvalidResponse
 }
 
 var oneLogLineRegex = regexp.MustCompile(`(?m)^\s*`)

--- a/client.go
+++ b/client.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -132,10 +131,6 @@ type Marathon interface {
 	Leader() (string, error)
 	// cause the current leader to abdicate
 	AbdicateLeader() (string, error)
-	// set log output
-	SetLogOutput(w io.Writer)
-	// set flags for logger
-	SetLogFlags(flag int)
 }
 
 var (
@@ -191,22 +186,9 @@ func NewClient(config Config) (Marathon, error) {
 	client.httpClient = &http.Client{
 		Timeout: (time.Duration(config.RequestTimeout) * time.Second),
 	}
-
-	// Discard all logging by default
-	client.debugLog = log.New(ioutil.Discard, "", 0)
+	client.debugLog = log.New(config.LogOutput, "", 0)
 
 	return client, nil
-}
-
-// SetLogOutput sets the output for go-marathon's debug log.
-// The default output is `ioutil.Discard`.
-func (r *marathonClient) SetLogOutput(w io.Writer) {
-	r.debugLog.SetOutput(w)
-}
-
-// SetLogFlags sets the flags for go-marathon's debug log.
-func (r *marathonClient) SetLogFlags(flag int) {
-	r.debugLog.SetFlags(flag)
 }
 
 // GetMarathonURL retrieves the marathon url

--- a/client_test.go
+++ b/client_test.go
@@ -37,3 +37,18 @@ func TestGetMarathonURL(t *testing.T) {
 
 	assert.Equal(t, endpoint.Client.GetMarathonURL(), endpoint.URL)
 }
+
+func TestOneLogLine(t *testing.T) {
+	in := `
+	a
+	b    c
+	d\n
+	  efgh
+	i\r\n
+	j\t
+	{"json":  "works",
+		"f o o": "ba    r"
+	}
+	`
+	assert.Equal(t, `a\n b    c\n d\n\n efgh\n i\r\n\n j\t\n {"json":  "works",\n "f o o": "ba    r"\n }\n `, string(oneLogLine([]byte(in))))
+}

--- a/client_test.go
+++ b/client_test.go
@@ -26,9 +26,9 @@ func TestPing(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, nil)
 	defer endpoint.Close()
 
-	found, err := endpoint.Client.Ping()
+	pong, err := endpoint.Client.Ping()
 	assert.NoError(t, err)
-	assert.True(t, found)
+	assert.True(t, pong)
 }
 
 func TestGetMarathonURL(t *testing.T) {

--- a/cluster.go
+++ b/cluster.go
@@ -168,6 +168,7 @@ func (r *marathonCluster) GetMember() (string, error) {
 	}
 
 	// we reached the end and there were no members available
+	defer r.MarkDown()
 	return "", ErrMarathonDown
 }
 

--- a/config.go
+++ b/config.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package marathon
 
+import (
+	"io"
+	"io/ioutil"
+)
+
 // EventsTransport describes which transport should be used to deliver Marathon events
 type EventsTransport int
 
@@ -37,6 +42,8 @@ type Config struct {
 	HTTPBasicPassword string
 	// custom callback url
 	CallbackURL string
+	// the output for debug log messages
+	LogOutput io.Writer
 }
 
 // NewDefaultConfig create a default client config
@@ -47,5 +54,6 @@ func NewDefaultConfig() Config {
 		EventsPort:      10001,
 		EventsInterface: "eth0",
 		RequestTimeout:  5,
+		LogOutput:       ioutil.Discard,
 	}
 }

--- a/const.go
+++ b/const.go
@@ -16,9 +16,11 @@ limitations under the License.
 
 package marathon
 
-const (
-	debugLevel = 10
+import (
+	"log"
+)
 
+const (
 	defaultEventsURL = "/event"
 
 	/* --- api related constants --- */
@@ -42,3 +44,7 @@ const (
 	// EventsTransportSSE activates stream events transport
 	EventsTransportSSE
 )
+
+func init() {
+	log.SetFlags(log.Ltime | log.Ldate | log.Lshortfile)
+}

--- a/const.go
+++ b/const.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package marathon
 
-import (
-	"log"
-)
-
 const (
 	defaultEventsURL = "/event"
 
@@ -44,7 +40,3 @@ const (
 	// EventsTransportSSE activates stream events transport
 	EventsTransportSSE
 )
-
-func init() {
-	log.SetFlags(log.Ltime | log.Ldate | log.Lshortfile)
-}

--- a/examples/applications/main.go
+++ b/examples/applications/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	marathon "github.com/gambol99/go-marathon"
 	"log"
 	"time"
+
+	marathon "github.com/gambol99/go-marathon"
 )
 
 var marathonURL string

--- a/examples/applications/main.go
+++ b/examples/applications/main.go
@@ -18,11 +18,9 @@ package main
 
 import (
 	"flag"
-	"time"
-
 	marathon "github.com/gambol99/go-marathon"
-
-	"github.com/golang/glog"
+	"log"
+	"time"
 )
 
 var marathonURL string
@@ -33,7 +31,7 @@ func init() {
 
 func assert(err error) {
 	if err != nil {
-		glog.Fatalf("Failed, error: %s", err)
+		log.Fatalf("Failed, error: %s", err)
 	}
 }
 
@@ -50,18 +48,18 @@ func main() {
 	applications, err := client.Applications(nil)
 	assert(err)
 
-	glog.Infof("Found %d application running", len(applications.Apps))
+	log.Printf("Found %d application running", len(applications.Apps))
 	for _, application := range applications.Apps {
-		glog.Infof("Application: %s", application)
+		log.Printf("Application: %v", application)
 		details, err := client.Application(application.ID)
 		assert(err)
 		if details.Tasks != nil && len(details.Tasks) > 0 {
 			for _, task := range details.Tasks {
-				glog.Infof("task: %s", task)
+				log.Printf("task: %s", task)
 			}
 			health, err := client.ApplicationOK(details.ID)
 			assert(err)
-			glog.Infof("Application: %s, healthy: %t", details.ID, health)
+			log.Printf("Application: %s, healthy: %t", details.ID, health)
 		}
 	}
 
@@ -73,7 +71,7 @@ func main() {
 		waitOnDeployment(client, deployID)
 	}
 
-	glog.Infof("Deploying a new application")
+	log.Printf("Deploying a new application")
 	application := marathon.NewDockerApplication()
 	application.Name(applicationName)
 	application.CPU(0.1).Memory(64).Storage(0.0).Count(2)
@@ -85,24 +83,24 @@ func main() {
 	_, err = client.CreateApplication(application)
 	assert(err)
 
-	glog.Infof("Scaling the application to 4 instances")
+	log.Printf("Scaling the application to 4 instances")
 	deployID, err := client.ScaleApplicationInstances(application.ID, 4, false)
 	assert(err)
 	client.WaitOnApplication(application.ID, 30*time.Second)
-	glog.Infof("Successfully scaled the application, deployID: %s", deployID.DeploymentID)
+	log.Printf("Successfully scaled the application, deployID: %s", deployID.DeploymentID)
 
-	glog.Infof("Deleting the application: %s", applicationName)
+	log.Printf("Deleting the application: %s", applicationName)
 	deployID, err = client.DeleteApplication(application.ID)
 	assert(err)
 	time.Sleep(time.Duration(10) * time.Second)
-	glog.Infof("Successfully deleted the application")
+	log.Printf("Successfully deleted the application")
 
-	glog.Infof("Starting the application again")
+	log.Printf("Starting the application again")
 	_, err = client.CreateApplication(application)
 	assert(err)
-	glog.Infof("Created the application: %s", application.ID)
+	log.Printf("Created the application: %s", application.ID)
 
-	glog.Infof("Delete all the tasks")
+	log.Printf("Delete all the tasks")
 	_, err = client.KillApplicationTasks(application.ID, "", false)
 	assert(err)
 }

--- a/examples/events_callback_transport/main.go
+++ b/examples/events_callback_transport/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	marathon "github.com/gambol99/go-marathon"
 	"log"
 	"time"
+
+	marathon "github.com/gambol99/go-marathon"
 )
 
 var marathonURL string

--- a/examples/events_callback_transport/main.go
+++ b/examples/events_callback_transport/main.go
@@ -18,11 +18,9 @@ package main
 
 import (
 	"flag"
-	"time"
-
 	marathon "github.com/gambol99/go-marathon"
-
-	"github.com/golang/glog"
+	"log"
+	"time"
 )
 
 var marathonURL string
@@ -39,7 +37,7 @@ func init() {
 
 func assert(err error) {
 	if err != nil {
-		glog.Fatalf("Failed, error: %s", err)
+		log.Fatalf("Failed, error: %s", err)
 	}
 }
 
@@ -49,7 +47,7 @@ func main() {
 	config.URL = marathonURL
 	config.EventsInterface = marathonInterface
 	config.EventsPort = marathonPort
-	glog.Infof("Creating a client, Marathon: %s", marathonURL)
+	log.Printf("Creating a client, Marathon: %s", marathonURL)
 
 	client, err := marathon.NewClient(config)
 	assert(err)
@@ -69,19 +67,19 @@ func main() {
 		}
 		select {
 		case <-timer:
-			glog.Infof("Exiting the loop")
+			log.Printf("Exiting the loop")
 			done = true
 		case event := <-events:
-			glog.Infof("Recieved application event: %s", event)
+			log.Printf("Recieved application event: %s", event)
 		case event := <-deployments:
-			glog.Infof("Recieved deployment event: %v", event)
+			log.Printf("Recieved deployment event: %v", event)
 			var deployment *marathon.EventDeploymentStepSuccess
 			deployment = event.Event.(*marathon.EventDeploymentStepSuccess)
-			glog.Infof("deployment step: %v", deployment.CurrentStep)
+			log.Printf("deployment step: %v", deployment.CurrentStep)
 		}
 	}
 
-	glog.Infof("Removing our subscription")
+	log.Printf("Removing our subscription")
 	client.RemoveEventsListener(events)
 	client.RemoveEventsListener(deployments)
 }

--- a/examples/events_sse_transport/main.go
+++ b/examples/events_sse_transport/main.go
@@ -18,11 +18,9 @@ package main
 
 import (
 	"flag"
-	"time"
-
 	marathon "github.com/gambol99/go-marathon"
-
-	"github.com/golang/glog"
+	"log"
+	"time"
 )
 
 var marathonURL string
@@ -35,7 +33,7 @@ func init() {
 
 func assert(err error) {
 	if err != nil {
-		glog.Fatalf("Failed, error: %s", err)
+		log.Fatalf("Failed, error: %s", err)
 	}
 }
 
@@ -44,7 +42,7 @@ func main() {
 	config := marathon.NewDefaultConfig()
 	config.URL = marathonURL
 	config.EventsTransport = marathon.EventsTransportSSE
-	glog.Infof("Creating a client, Marathon: %s", marathonURL)
+	log.Printf("Creating a client, Marathon: %s", marathonURL)
 
 	client, err := marathon.NewClient(config)
 	assert(err)
@@ -64,19 +62,19 @@ func main() {
 		}
 		select {
 		case <-timer:
-			glog.Infof("Exiting the loop")
+			log.Printf("Exiting the loop")
 			done = true
 		case event := <-events:
-			glog.Infof("Recieved application event: %s", event)
+			log.Printf("Recieved application event: %s", event)
 		case event := <-deployments:
-			glog.Infof("Recieved deployment event: %v", event)
+			log.Printf("Recieved deployment event: %v", event)
 			var deployment *marathon.EventDeploymentStepSuccess
 			deployment = event.Event.(*marathon.EventDeploymentStepSuccess)
-			glog.Infof("deployment step: %v", deployment.CurrentStep)
+			log.Printf("deployment step: %v", deployment.CurrentStep)
 		}
 	}
 
-	glog.Infof("Removing our subscription")
+	log.Printf("Removing our subscription")
 	client.RemoveEventsListener(events)
 	client.RemoveEventsListener(deployments)
 }

--- a/examples/events_sse_transport/main.go
+++ b/examples/events_sse_transport/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	marathon "github.com/gambol99/go-marathon"
 	"log"
 	"time"
+
+	marathon "github.com/gambol99/go-marathon"
 )
 
 var marathonURL string

--- a/examples/glog/main.go
+++ b/examples/glog/main.go
@@ -32,8 +32,6 @@ func (l *logBridge) Write(b []byte) (n int, err error) {
 	return len(b), nil
 }
 
-var lb = new(logBridge)
-
 func init() {
 	flag.StringVar(&marathonURL, "url", "http://127.0.0.1:8080", "the url for the marathon endpoint")
 }
@@ -42,11 +40,11 @@ func main() {
 	flag.Parse()
 	config := marathon.NewDefaultConfig()
 	config.URL = marathonURL
+	config.LogOutput = new(logBridge)
 	client, err := marathon.NewClient(config)
 	if err != nil {
 		glog.Exitln(err)
 	}
-	client.SetLogOutput(lb)
 
 	applications, err := client.Applications(nil)
 	if err != nil {

--- a/examples/glog/main.go
+++ b/examples/glog/main.go
@@ -12,6 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// go run main.go -logtostderr
+
 package main
 
 import (
@@ -23,9 +25,16 @@ import (
 
 var marathonURL string
 
-func init() {
-	glog.CopyStandardLogTo("INFO") // redirect marathon logs to glog
+type logBridge struct{}
 
+func (l *logBridge) Write(b []byte) (n int, err error) {
+	glog.InfoDepth(3, "go-marathon: "+string(b))
+	return len(b), nil
+}
+
+var lb = new(logBridge)
+
+func init() {
 	flag.StringVar(&marathonURL, "url", "http://127.0.0.1:8080", "the url for the marathon endpoint")
 }
 
@@ -37,6 +46,7 @@ func main() {
 	if err != nil {
 		glog.Exitln(err)
 	}
+	client.SetLogOutput(lb)
 
 	applications, err := client.Applications(nil)
 	if err != nil {

--- a/examples/glog/main.go
+++ b/examples/glog/main.go
@@ -1,0 +1,48 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	marathon "github.com/gambol99/go-marathon"
+	"github.com/golang/glog"
+)
+
+var marathonURL string
+
+func init() {
+	glog.CopyStandardLogTo("INFO") // redirect marathon logs to glog
+
+	flag.StringVar(&marathonURL, "url", "http://127.0.0.1:8080", "the url for the marathon endpoint")
+}
+
+func main() {
+	flag.Parse()
+	config := marathon.NewDefaultConfig()
+	config.URL = marathonURL
+	client, err := marathon.NewClient(config)
+	if err != nil {
+		glog.Exitln(err)
+	}
+
+	applications, err := client.Applications(nil)
+	if err != nil {
+		glog.Exitln(err)
+	}
+
+	for _, a := range applications.Apps {
+		glog.Infof("App ID: %v\n", a.ID)
+	}
+}

--- a/examples/glog/main.go
+++ b/examples/glog/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"flag"
+
 	marathon "github.com/gambol99/go-marathon"
 	"github.com/golang/glog"
 )

--- a/examples/groups/main.go
+++ b/examples/groups/main.go
@@ -18,10 +18,9 @@ package main
 
 import (
 	"flag"
-	"time"
-
 	marathon "github.com/gambol99/go-marathon"
-	"github.com/golang/glog"
+	"log"
+	"time"
 )
 
 var marathonURL string
@@ -32,7 +31,7 @@ func init() {
 
 func assert(err error) {
 	if err != nil {
-		glog.Fatalf("Failed, error: %s", err)
+		log.Fatalf("Failed, error: %s", err)
 	}
 }
 
@@ -42,15 +41,15 @@ func main() {
 	config.URL = marathonURL
 	client, err := marathon.NewClient(config)
 	if err != nil {
-		glog.Fatalf("Failed to create a client for marathon, error: %s", err)
+		log.Fatalf("Failed to create a client for marathon, error: %s", err)
 	}
 
-	glog.Infof("Retrieving a list of groups")
+	log.Printf("Retrieving a list of groups")
 	if groups, err := client.Groups(); err != nil {
-		glog.Errorf("Failed to retrieve the groups from maratho, error: %s", err)
+		log.Fatalf("Failed to retrieve the groups from maratho, error: %s", err)
 	} else {
 		for _, group := range groups.Groups {
-			glog.Infof("Found group: %s", group.ID)
+			log.Printf("Found group: %s", group.ID)
 		}
 	}
 
@@ -59,7 +58,7 @@ func main() {
 	found, err := client.HasGroup(groupName)
 	assert(err)
 	if found {
-		glog.Infof("Deleting the grouy: %s, as it already exists", groupName)
+		log.Printf("Deleting the group: %s, as it already exists", groupName)
 		id, err := client.DeleteGroup(groupName)
 		assert(err)
 		err = client.WaitOnDeployment(id.DeploymentID, 0)
@@ -105,13 +104,13 @@ func main() {
 	group.App(frontend).App(redis).App(mysql)
 
 	assert(client.CreateGroup(group))
-	glog.Infof("Successfully created the group: %s", group.ID)
+	log.Printf("Successfully created the group: %s", group.ID)
 
-	glog.Infof("Updating the group paramaters")
+	log.Printf("Updating the group paramaters")
 	frontend.Count(4)
 
 	id, err := client.UpdateGroup(groupName, group)
 	assert(err)
-	glog.Infof("Successfully updated the group: %s, version: %s", group.ID, id.DeploymentID)
+	log.Printf("Successfully updated the group: %s, version: %s", group.ID, id.DeploymentID)
 	assert(client.WaitOnGroup(groupName, 500*time.Second))
 }

--- a/examples/groups/main.go
+++ b/examples/groups/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	marathon "github.com/gambol99/go-marathon"
 	"log"
 	"time"
+
+	marathon "github.com/gambol99/go-marathon"
 )
 
 var marathonURL string

--- a/examples/multiple_endpoints/main.go
+++ b/examples/multiple_endpoints/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	marathon "github.com/gambol99/go-marathon"
 	"log"
 	"time"
+
+	marathon "github.com/gambol99/go-marathon"
 )
 
 var marathonURL string

--- a/examples/multiple_endpoints/main.go
+++ b/examples/multiple_endpoints/main.go
@@ -18,11 +18,9 @@ package main
 
 import (
 	"flag"
-	"time"
-
 	marathon "github.com/gambol99/go-marathon"
-
-	"github.com/golang/glog"
+	"log"
+	"time"
 )
 
 var marathonURL string
@@ -37,15 +35,15 @@ func main() {
 	config.URL = marathonURL
 	client, err := marathon.NewClient(config)
 	if err != nil {
-		glog.Fatalf("Failed to create a client for marathon, error: %s", err)
+		log.Fatalf("Failed to create a client for marathon, error: %s", err)
 	}
 	for {
 		if application, err := client.Applications(nil); err != nil {
-			glog.Errorf("Failed to retrieve a list of applications, error: %s", err)
+			log.Fatalf("Failed to retrieve a list of applications, error: %s", err)
 		} else {
-			glog.Infof("Retrieved a list of applications, %v", application)
-		}	
-		glog.Infof("Going to sleep for 20 seconds")
+			log.Printf("Retrieved a list of applications, %v", application)
+		}
+		log.Printf("Going to sleep for 20 seconds")
 		time.Sleep(5 * time.Second)
 	}
 }

--- a/group.go
+++ b/group.go
@@ -88,15 +88,14 @@ func (r *marathonClient) Group(name string) (*Group, error) {
 // 		name:			the identifier for the group
 func (r *marathonClient) HasGroup(name string) (bool, error) {
 	uri := fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name))
-	status, _, err := r.apiCall("GET", uri, "", nil)
-	if err == nil {
-		return true, nil
+	err := r.apiCall("GET", uri, "", nil)
+	if err != nil {
+		if err == ErrDoesNotExist {
+			return false, nil
+		}
+		return false, err
 	}
-	if status == 404 {
-		return false, nil
-	}
-
-	return false, err
+	return true, nil
 }
 
 // CreateGroup creates a new group in marathon

--- a/subscription.go
+++ b/subscription.go
@@ -19,13 +19,14 @@ package marathon
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/donovanhide/eventsource"
 	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/donovanhide/eventsource"
 )
 
 // Subscriptions is a collection to urls that marathon is implementing a callback on

--- a/subscription.go
+++ b/subscription.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -178,11 +177,11 @@ func (r *marathonClient) registerSSESubscription() error {
 			case ev := <-stream.Events:
 				if err := r.handleEvent(ev.Data()); err != nil {
 					// TODO let the user handle this error instead of logging it here
-					log.Printf("registerSSESubscription(): failed to handle event: %v\n", err)
+					r.debugLog.Printf("registerSSESubscription(): failed to handle event: %v\n", err)
 				}
 			case err := <-stream.Errors:
 				// TODO let the user handle this error instead of logging it here
-				log.Printf("registerSSESubscription(): failed to receive event: %v\n", err)
+				r.debugLog.Printf("registerSSESubscription(): failed to receive event: %v\n", err)
 			}
 		}
 	}()
@@ -256,12 +255,12 @@ func (r *marathonClient) handleCallbackEvent(writer http.ResponseWriter, request
 	body, err := ioutil.ReadAll(request.Body)
 	if err != nil {
 		// TODO should this return a 500?
-		log.Printf("handleCallbackEvent(): failed to read request body, error: %s\n", err)
+		r.debugLog.Printf("handleCallbackEvent(): failed to read request body, error: %s\n", err)
 		return
 	}
 
 	if err := r.handleEvent(string(body[:])); err != nil {
 		// TODO should this return a 500?
-		log.Printf("handleCallbackEvent(): failed to handle event: %v\n", err)
+		r.debugLog.Printf("handleCallbackEvent(): failed to handle event: %v\n", err)
 	}
 }

--- a/subscription.go
+++ b/subscription.go
@@ -56,7 +56,6 @@ func (r *marathonClient) AddEventsListener(channel EventsChannel, filter int) er
 	}
 
 	if _, found := r.listeners[channel]; !found {
-		log.Printf("adding a watch for events: %d, channel: %v", filter, channel)
 		r.listeners[channel] = filter
 	}
 	return nil

--- a/testing_utils.go
+++ b/testing_utils.go
@@ -22,7 +22,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -83,13 +82,13 @@ func newFakeMarathonEndpoint(t *testing.T, config *Config) *endpoint {
 		// step: open and read in the methods yaml
 		contents, err := ioutil.ReadFile(fakeAPIFilename)
 		if err != nil {
-			log.Fatalf("unable to read in the methods yaml file: %s", fakeAPIFilename)
+			t.Fatalf("unable to read in the methods yaml file: %s", fakeAPIFilename)
 		}
 		// step: unmarshal the yaml
 		var methods []*restMethod
 		err = yaml.Unmarshal([]byte(contents), &methods)
 		if err != nil {
-			log.Fatalf("Unable to unmarshal the methods yaml, error: %s", err)
+			t.Fatalf("Unable to unmarshal the methods yaml, error: %s", err)
 		}
 
 		// step: construct a hash from the methods

--- a/testing_utils.go
+++ b/testing_utils.go
@@ -18,8 +18,6 @@ package marathon
 
 import (
 	"fmt"
-	"github.com/donovanhide/eventsource"
-	yaml "gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -28,6 +26,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/donovanhide/eventsource"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (

--- a/testing_utils.go
+++ b/testing_utils.go
@@ -18,18 +18,17 @@ package marathon
 
 import (
 	"fmt"
+	"github.com/donovanhide/eventsource"
+	yaml "gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"sync"
 	"testing"
-
-	"github.com/donovanhide/eventsource"
-	"github.com/golang/glog"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -84,13 +83,13 @@ func newFakeMarathonEndpoint(t *testing.T, config *Config) *endpoint {
 		// step: open and read in the methods yaml
 		contents, err := ioutil.ReadFile(fakeAPIFilename)
 		if err != nil {
-			glog.Fatalf("unable to read in the methods yaml file: %s", fakeAPIFilename)
+			log.Fatalf("unable to read in the methods yaml file: %s", fakeAPIFilename)
 		}
 		// step: unmarshal the yaml
 		var methods []*restMethod
 		err = yaml.Unmarshal([]byte(contents), &methods)
 		if err != nil {
-			glog.Fatalf("Unable to unmarshal the methods yaml, error: %s", err)
+			log.Fatalf("Unable to unmarshal the methods yaml, error: %s", err)
 		}
 
 		// step: construct a hash from the methods


### PR DESCRIPTION
* Replace glog with pkg/log
* Added an glog example app
* No multiline logging anymore (which makes it easier for anything that tries to parse log files)
* Removed random and inconsistent logging. Don't log in functions that return an error anyway for example. Let the user decide what to do with the error. 
* Cleaned up apiOperation/ apiCall /httpRequest
* Updated `func (r *marathonCluster) GetMember()` to call the `MarkDown` func. This separates concerns, and we don't have to worry about it in `httpRequest()` or in `registerSSESubscription()`

Can someone give me some feedback? :-)