### PR TITLE
Refactor HasApplication to return only error.

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -263,7 +263,7 @@ func TestApplicationOK(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestListApplication(t *testing.T) {
+func TestApplication(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, nil)
 	defer endpoint.Close()
 
@@ -275,25 +275,16 @@ func TestListApplication(t *testing.T) {
 	assert.NotNil(t, application.Tasks)
 	assert.Equal(t, len(application.HealthChecks), 1)
 	assert.Equal(t, len(application.Tasks), 2)
-}
 
-func TestHasApplication(t *testing.T) {
-	endpoint := newFakeMarathonEndpoint(t, nil)
-	defer endpoint.Close()
-
-	found, err := endpoint.Client.HasApplication(fakeAppName)
-	assert.NoError(t, err)
-	assert.True(t, found)
-
-	found, err = endpoint.Client.HasApplication("no_such_app")
-	assert.NoError(t, err)
-	assert.False(t, found)
+	_, err = endpoint.Client.Application("no_such_app")
+	assert.Equal(t, ErrDoesNotExist, err)
 
 	config := NewDefaultConfig()
 	config.URL = "http://non-existing-marathon-host.local:5555"
 	endpoint = newFakeMarathonEndpoint(t, &config)
+	defer endpoint.Close()
 
-	found, err = endpoint.Client.HasApplication(fakeAppName)
+	_, err = endpoint.Client.Application(fakeAppName)
+	assert.NotEqual(t, ErrDoesNotExist, err)
 	assert.Error(t, err)
-	assert.False(t, found)
 }

--- a/client.go
+++ b/client.go
@@ -34,8 +34,6 @@ import (
 type Marathon interface {
 	// -- APPLICATIONS ---
 
-	// check it see if a application exists
-	HasApplication(name string) (bool, error)
 	// get a listing of the application ids
 	ListApplications(url.Values) ([]string, error)
 	// a list of application versions

--- a/examples/applications/main.go
+++ b/examples/applications/main.go
@@ -66,7 +66,7 @@ func main() {
 
 	applicationName := "/my/product"
 
-	if found, _ := client.HasApplication(applicationName); found {
+	if _, err := client.Application(applicationName); err != nil {
 		deployID, err := client.DeleteApplication(applicationName)
 		assert(err)
 		waitOnDeployment(client, deployID)


### PR DESCRIPTION
This PR refactors `HasApplication` to return only error instead of `(bool, err)`. It was inspired by how go standard library deals in similar situations: http://stackoverflow.com/a/12518877/1047843

Now after rebasing with latest master I realised that `HasApplication` doesn't do a lot and it might be easier to just call `Application` instead.

What do you think @gambol99 @timoreimann @mattes ?