### PR TITLE
Refactor tasks

### DIFF
--- a/application.go
+++ b/application.go
@@ -192,12 +192,9 @@ func (r *Application) AddLabel(name, value string) *Application {
 	return r
 }
 
-// HasHealthChecks is more of a helper method, used to check if an application has healtchecks
+// HasHealthChecks is a helper method, used to check if an application has healtchecks
 func (r *Application) HasHealthChecks() bool {
-	if r.HealthChecks != nil && len(r.HealthChecks) > 0 {
-		return true
-	}
-	return false
+	return r.HealthChecks != nil && len(r.HealthChecks) > 0
 }
 
 // DeploymentIDs retrieves the application deployments IDs
@@ -369,13 +366,10 @@ func (r *marathonClient) ApplicationOK(name string) (bool, error) {
 
 	// step: iterate the application checks and look for false
 	for _, task := range application.Tasks {
-		if task.HealthCheckResult != nil {
-			for _, check := range task.HealthCheckResult {
+		if task.HealthCheckResults != nil {
+			for _, check := range task.HealthCheckResults {
 				//When a task is flapping in Marathon, this is sometimes nil
-				if check == nil {
-					return false, nil
-				}
-				if !check.Alive {
+				if check == nil || !check.Alive {
 					return false, nil
 				}
 			}

--- a/client.go
+++ b/client.go
@@ -68,15 +68,15 @@ type Marathon interface {
 	// get a list of tasks for a specific application
 	Tasks(application string) (*Tasks, error)
 	// get a list of all tasks
-	AllTasks(v url.Values) (*Tasks, error)
+	AllTasks(opts *AllTasksOpts) (*Tasks, error)
 	// get the endpoints for a service on a application
 	TaskEndpoints(name string, port int, healthCheck bool) ([]string, error)
 	// kill all the tasks for any application
-	KillApplicationTasks(applicationID, hostname string, scale bool) (*Tasks, error)
+	KillApplicationTasks(applicationID string, opts *KillApplicationTasksOpts) (*Tasks, error)
 	// kill a single task
-	KillTask(taskID string, scale bool) (*Task, error)
+	KillTask(taskID string, opts *KillTaskOpts) (*Task, error)
 	// kill the given array of tasks
-	KillTasks(taskIDs []string, scale bool) error
+	KillTasks(taskIDs []string, opts *KillTaskOpts) error
 
 	// --- GROUPS ---
 

--- a/examples/applications/main.go
+++ b/examples/applications/main.go
@@ -102,6 +102,6 @@ func main() {
 	log.Printf("Created the application: %s", application.ID)
 
 	log.Printf("Delete all the tasks")
-	_, err = client.KillApplicationTasks(application.ID, "", false)
+	_, err = client.KillApplicationTasks(application.ID, nil)
 	assert(err)
 }

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	marathon "github.com/gambol99/go-marathon"
+)
+
+const marathonURL = "http://127.0.0.1:8080"
+
+func main() {
+	config := marathon.NewDefaultConfig()
+	config.URL = marathonURL
+	client, err := marathon.NewClient(config)
+	if err != nil {
+		panic(err)
+	}
+
+	app := marathon.Application{}
+	app.ID = "tasks-test"
+	app.Cmd = "sleep 60"
+	app.Instances = 3
+	fmt.Println("Creating app.")
+	// Update application will either create or update the app.
+	_, err = client.UpdateApplication(&app)
+	if err != nil {
+		panic(err)
+	}
+
+	// wait until marathon will launch tasks
+	client.WaitOnApplication(app.ID, 10*time.Second)
+	fmt.Println("Tasks were deployed.")
+
+	tasks, err := client.Tasks(app.ID)
+	if err != nil {
+		panic(err)
+	}
+
+	host := tasks.Tasks[0].Host
+	fmt.Printf("Killing tasks on the host: %s\n", host)
+
+	_, err = client.KillApplicationTasks(app.ID, &marathon.KillApplicationTasksOpts{Scale: true, Host: host})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/task.go
+++ b/task.go
@@ -18,50 +18,71 @@ package marathon
 
 import (
 	"fmt"
-	"net/url"
-	"strconv"
 	"strings"
 )
 
-// Tasks ... a collection of marathon tasks
+// Tasks is a collection of marathon tasks
 type Tasks struct {
 	Tasks []Task `json:"tasks"`
 }
 
-// Task ... the definition for a marathon task
+// Task is the definition for a marathon task
 type Task struct {
-	ID                string               `json:"id"`
-	AppID             string               `json:"appId"`
-	Host              string               `json:"host"`
-	HealthCheckResult []*HealthCheckResult `json:"healthCheckResults"`
-	Ports             []int                `json:"ports"`
-	ServicePorts      []int                `json:"servicePorts"`
-	StagedAt          string               `json:"stagedAt"`
-	StartedAt         string               `json:"startedAt"`
-	Version           string               `json:"version"`
+	ID                 string               `json:"id"`
+	AppID              string               `json:"appId"`
+	Host               string               `json:"host"`
+	HealthCheckResults []*HealthCheckResult `json:"healthCheckResults"`
+	Ports              []int                `json:"ports"`
+	ServicePorts       []int                `json:"servicePorts"`
+	StagedAt           string               `json:"stagedAt"`
+	StartedAt          string               `json:"startedAt"`
+	Version            string               `json:"version"`
 }
 
-// HasHealthCheckResults ... Check if the task has any health checks
+// AllTasksOpts contains a payload for AllTasks method
+//		status:		Return only those tasks whose status matches this parameter.
+//				If not specified, all tasks are returned. Possible values: running, staging. Default: none.
+type AllTasksOpts struct {
+	Status string `url:"status,omitempty"`
+}
+
+// KillApplicationTasksOpts contains a payload for KillApplicationTasks method
+//		host:		kill only those tasks on a specific host (optional)
+//		scale:		Scale the app down (i.e. decrement its instances setting by the number of tasks killed) after killing the specified tasks
+type KillApplicationTasksOpts struct {
+	Host  string `url:"host,omitempty"`
+	Scale bool   `url:"scale,omitempty"`
+}
+
+// KillTaskOpts contains a payload for task killing methods
+//		scale:		Scale the app down
+type KillTaskOpts struct {
+	Scale bool `url:"scale,omitempty"`
+}
+
+// HasHealthCheckResults checks if the task has any health checks
 func (r *Task) HasHealthCheckResults() bool {
-	if r.HealthCheckResult == nil || len(r.HealthCheckResult) <= 0 {
-		return false
-	}
-	return true
+	return r.HealthCheckResults != nil && len(r.HealthCheckResults) > 0
 }
 
-// AllTasks list tasks of all applications.
-//		v:		Get parameters for the API call.
-func (r *marathonClient) AllTasks(v url.Values) (*Tasks, error) {
+// AllTasks lists tasks of all applications.
+//		opts: 		AllTasksOpts request payload
+func (r *marathonClient) AllTasks(opts *AllTasksOpts) (*Tasks, error) {
+	u, err := addOptions(marathonAPITasks, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	tasks := new(Tasks)
-	if err := r.apiGet(marathonAPITasks+"?"+v.Encode(), nil, tasks); err != nil {
+	if err := r.apiGet(u, nil, tasks); err != nil {
 		return nil, err
 	}
 
 	return tasks, nil
 }
 
-// Tasks ... Retrieve a list of tasks for an application
-//		application_id:		the id for the application
+// Tasks retrieves a list of tasks for an application
+//		id:		the id of the application
 func (r *marathonClient) Tasks(id string) (*Tasks, error) {
 	tasks := new(Tasks)
 	if err := r.apiGet(fmt.Sprintf("%s/%s/tasks", marathonAPIApps, trimRootPath(id)), nil, tasks); err != nil {
@@ -71,57 +92,65 @@ func (r *marathonClient) Tasks(id string) (*Tasks, error) {
 	return tasks, nil
 }
 
-// KillApplicationTasks ... Kill all tasks relating to an application
-//		application_id:		the id for the application
-//      host:				kill only those tasks on a specific host (optional)
-//		scale:              Scale the app down (i.e. decrement its instances setting by the number of tasks killed) after killing the specified tasks
-func (r *marathonClient) KillApplicationTasks(id, hostname string, scale bool) (*Tasks, error) {
-	var options struct {
-		Host  string `json:"host"`
-		Scale bool   `json:"bool"`
+// KillApplicationTasks kills all tasks relating to an application
+//		id:		the id of the application
+//		opts: 		KillApplicationTasksOpts request payload
+func (r *marathonClient) KillApplicationTasks(id string, opts *KillApplicationTasksOpts) (*Tasks, error) {
+	u := fmt.Sprintf("%s/%s/tasks", marathonAPIApps, trimRootPath(id))
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil, err
 	}
-	options.Host = hostname
-	options.Scale = scale
+
 	tasks := new(Tasks)
-	if err := r.apiDelete(fmt.Sprintf("%s/%s/tasks", marathonAPIApps, trimRootPath(id)), &options, tasks); err != nil {
+	if err := r.apiDelete(u, nil, tasks); err != nil {
 		return nil, err
 	}
 
 	return tasks, nil
 }
 
-// KillTask ... Kill the task associated with a given ID
-// 	task_id:		the id for the task
-// 	scale:		Scale the app down
-func (r *marathonClient) KillTask(taskID string, scale bool) (*Task, error) {
-	var options struct {
-		Scale bool `json:"bool"`
-	}
-	options.Scale = scale
-	task := new(Task)
+// KillTask kills the task associated with a given ID
+// 	taskID:		the id for the task
+//	opts:		KillTaskOpts request payload
+func (r *marathonClient) KillTask(taskID string, opts *KillTaskOpts) (*Task, error) {
 	appName := taskID[0:strings.LastIndex(taskID, ".")]
-	if err := r.apiDelete(fmt.Sprintf("%s/%s/tasks/%s", marathonAPIApps, appName, taskID), &options, task); err != nil {
+	u := fmt.Sprintf("%s/%s/tasks/%s", marathonAPIApps, appName, taskID)
+	u, err := addOptions(u, opts)
+	if err != nil {
 		return nil, err
 	}
 
-	return task, nil
-}
+	wrappedTask := new(struct {
+		Task Task `json:"task"`
+	})
 
-// KillTasks ... Kill tasks associated with given array of ids
-// 	tasks: 	the array of task ids
-// 	scale: 	Scale the app down
-func (r *marathonClient) KillTasks(tasks []string, scale bool) error {
-	v := url.Values{}
-	v.Add("scale", strconv.FormatBool(scale))
-	var post struct {
-		TaskIDs []string `json:"ids"`
+	if err := r.apiDelete(u, nil, wrappedTask); err != nil {
+		return nil, err
 	}
-	post.TaskIDs = tasks
 
-	return r.apiPost(fmt.Sprintf("%s/delete?%s", marathonAPITasks, v.Encode()), &post, nil)
+	return &wrappedTask.Task, nil
 }
 
-// TaskEndpoints ... Get the endpoints i.e. HOST_IP:DYNAMIC_PORT for a specific application service
+// KillTasks kills tasks associated with given array of ids
+//	tasks:		the array of task ids
+//	opts:		KillTaskOpts request payload
+func (r *marathonClient) KillTasks(tasks []string, opts *KillTaskOpts) error {
+	u := fmt.Sprintf("%s/delete", marathonAPITasks)
+	u, err := addOptions(u, opts)
+	if err != nil {
+		return nil
+	}
+
+	var post struct {
+		IDs []string `json:"ids"`
+	}
+	post.IDs = tasks
+
+	return r.apiPost(u, &post, nil)
+}
+
+// TaskEndpoints gets the endpoints i.e. HOST_IP:DYNAMIC_PORT for a specific application service
 // I.e. a container running apache, might have ports 80/443 (translated to X dynamic ports), but i want
 // port 80 only and i only want those whom have passed the health check
 //
@@ -146,39 +175,38 @@ func (r *marathonClient) TaskEndpoints(name string, port int, healthCheck bool) 
 		return nil, err
 	}
 
-	var list []string
 	// step: do we have any tasks?
 	if application.Tasks == nil || len(application.Tasks) <= 0 {
-		return list, nil
+		return nil, nil
 	}
 
+	// step: if we are checking health the 'service' has a health check?
+	healthCheck = healthCheck && application.HasHealthChecks()
+
 	// step: iterate the tasks and extract the dynamic ports
+	var list []string
 	for _, task := range application.Tasks {
-		// step: if we are checking health the 'service' has a health check?
-		if healthCheck && application.HasHealthChecks() {
-			/*
-				check: does the task have a health check result, if NOT, it's because the
-				health of the task hasn't yet been performed, hence we assume it as DOWN
-			*/
-			if task.HasHealthCheckResults() == false {
-				continue
-			}
-
-			// step: check the health results then
-			skipEndpoint := false
-			for _, health := range task.HealthCheckResult {
-				if health.Alive == false {
-					skipEndpoint = true
-				}
-			}
-
-			if skipEndpoint == true {
-				continue
-			}
+		if !healthCheck || task.allHealthChecksAlive() {
+			endpoint := fmt.Sprintf("%s:%d", task.Host, task.Ports[portIndex])
+			list = append(list, endpoint)
 		}
-		// else we can just add it
-		list = append(list, fmt.Sprintf("%s:%d", task.Host, task.Ports[portIndex]))
 	}
 
 	return list, nil
+}
+
+func (r *Task) allHealthChecksAlive() bool {
+	// check: does the task have a health check result, if NOT, it's because the
+	// health of the task hasn't yet been performed, hence we assume it as DOWN
+	if !r.HasHealthCheckResults() {
+		return false
+	}
+	// step: check the health results then
+	for _, check := range r.HealthCheckResults {
+		if check.Alive == false {
+			return false
+		}
+	}
+
+	return true
 }

--- a/testing_utils_test.go
+++ b/testing_utils_test.go
@@ -36,6 +36,7 @@ const (
 	fakeGroupName     = "/test"
 	fakeGroupName1    = "/qa/product/1"
 	fakeAppName       = "/fake_app"
+	fakeTaskID        = "fake_app.12345"
 	fakeAppNameBroken = "/fake_app_broken"
 	fakeDeploymentID  = "867ed450-f6a8-4d33-9b0e-e11c5513990b"
 	fakeAPIFilename   = "./tests/rest-api/methods.yml"

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -218,10 +218,22 @@
       "version": "2014-08-26T07:37:50.462Z"
     }
 - uri: /v2/apps/fake_app/tasks
+  method: GET
+  content: |
+    {
+        "tasks": [{"id": "1"},{"id": "2"}]
+    }
+- uri: /v2/apps/fake_app/tasks
   method: DELETE
   content: |
     {
         "tasks": []
+    }
+- uri: /v2/apps/fake_app/tasks/fake_app.12345
+  method: DELETE
+  content: |
+    {
+        "task": {"id": "fake_app.12345"}
     }
 - uri: /v2/apps/fake_app
   method: GET
@@ -757,6 +769,8 @@
   method: GET
   content: |
     {"tasks":[]}
+- uri: /v2/tasks/delete
+  method: POST
 - uri: /v2/deployments
   method: GET
   content: |


### PR DESCRIPTION
I tried to go through `tasks.go` and refactor/fix some code:
- fixes https://github.com/gambol99/go-marathon/issues/112
- fixes return value for `KillTask`
- introduced options for requests, removed url string manipulation
- added missing tests
- added tasks example
- refactored here and there

> introduced options for requests

I remember we discussed it once, however I went back to this idea after trying to understand what `AllTasks(v url.Values)` does. In order to use this method, one needs to:
- check go `url.Values` documentation
- check marathon rest api documentation (which the library tries to abstract)
- combine them together

I don't think that it would be a problem to update the library if marathon will introduce new parameters. Moreover, it happens quite rarely.

If you don't agree with the options struct, I'm happy to move it back to `url.Values`.