### PR TITLE
Check for empty Marathon hosts; include tests for newCluster.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -102,6 +102,10 @@ func newCluster(marathonURL string) (Cluster, error) {
 	/* step: create a link list of the hosts */
 	var previous *marathonNode
 	for index, host := range strings.SplitN(marathon.Host, ",", -1) {
+		if len(host) == 0 {
+			return nil, ErrInvalidEndpoint
+		}
+
 		// step: create a new cluster member
 		node := new(marathonNode)
 		node.hostname = host

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -62,3 +62,19 @@ func TestMarkDown(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	assert.Equal(t, len(cluster.Active()), 3)
 }
+
+func TestInvalidHosts(t *testing.T) {
+	for _, invalidHost := range []string{
+		"",
+		"://",
+		"http://",
+		"http://,,",
+		"http://,127.0.0.1:3000,127.0.0.1:3000",
+		"http://127.0.0.1:3000,,127.0.0.1:3000",
+		"http://127.0.0.1:3000,127.0.0.1:3000,",
+		"foo://127.0.0.1:3000",
+	} {
+		_, err := newCluster(invalidHost)
+		assert.Equal(t, err, ErrInvalidEndpoint, "undetected invalid host: %s", invalidHost)
+	}
+}


### PR DESCRIPTION
The newCluster was missing test coverage and would not mark empty hosts as an error. This change fixes both.

Closes #104