### PR TITLE
Parse API error responses.

### DIFF
--- a/application.go
+++ b/application.go
@@ -419,7 +419,7 @@ func (r *marathonClient) WaitOnApplication(name string, timeout time.Duration) e
 		}()
 		for !flick.IsSwitched() {
 			app, err := r.Application(name)
-			if err != nil && err != ErrDoesNotExist {
+			if apiErr, ok := err.(*APIError); ok && apiErr.ErrCode == ErrCodeNotFound {
 				continue
 			}
 			if err == nil && app.AllTaskRunning() {

--- a/application_test.go
+++ b/application_test.go
@@ -277,7 +277,10 @@ func TestApplication(t *testing.T) {
 	assert.Equal(t, len(application.Tasks), 2)
 
 	_, err = endpoint.Client.Application("no_such_app")
-	assert.Equal(t, ErrDoesNotExist, err)
+	assert.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	assert.True(t, ok)
+	assert.Equal(t, ErrCodeNotFound, apiErr.ErrCode)
 
 	config := NewDefaultConfig()
 	config.URL = "http://non-existing-marathon-host.local:5555"
@@ -285,6 +288,7 @@ func TestApplication(t *testing.T) {
 	defer endpoint.Close()
 
 	_, err = endpoint.Client.Application(fakeAppName)
-	assert.NotEqual(t, ErrDoesNotExist, err)
 	assert.Error(t, err)
+	_, ok = err.(*APIError)
+	assert.False(t, ok)
 }

--- a/error.go
+++ b/error.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2015 Rohith All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	// ErrCodeBadRequest specifies a 400 Bad Request error.
+	ErrCodeBadRequest = iota
+	// ErrCodeUnauthorized specifies a 401 Unauthorized error.
+	ErrCodeUnauthorized
+	// ErrCodeForbidden specifies a 403 Forbidden error.
+	ErrCodeForbidden
+	// ErrCodeNotFound specifies a 404 Not Found error.
+	ErrCodeNotFound
+	// ErrCodeDuplicateID specifies a PUT 409 Conflict error.
+	ErrCodeDuplicateID
+	// ErrCodeAppLocked specifies a POST 409 Conflict error.
+	ErrCodeAppLocked
+	// ErrCodeInvalidBean specifies a 422 UnprocessableEntity error.
+	ErrCodeInvalidBean
+	// ErrCodeServer specifies a 500+ Server error.
+	ErrCodeServer
+	// ErrCodeUnknown specifies an unknown error.
+	ErrCodeUnknown
+)
+
+// APIError represents a generic API error.
+type APIError struct {
+	// ErrCode specifies the nature of the error.
+	ErrCode int
+	message string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("Marathon API error: %s", e.message)
+}
+
+// NewAPIError creates a new APIError instance from the given response code and content.
+func NewAPIError(code int, content []byte) (*APIError, error) {
+	switch {
+	case code == http.StatusBadRequest:
+		return parseContent(&badRequestDef{}, content)
+	case code == http.StatusUnauthorized:
+		return parseContent(&simpleErrDef{code: ErrCodeUnauthorized}, content)
+	case code == http.StatusForbidden:
+		return parseContent(&simpleErrDef{code: ErrCodeForbidden}, content)
+	case code == http.StatusNotFound:
+		return parseContent(&simpleErrDef{code: ErrCodeNotFound}, content)
+	case code == http.StatusConflict:
+		return parseContent(&conflictDef{}, content)
+	case code == 422:
+		return parseContent(&unprocessableEntityDef{}, content)
+	case code >= http.StatusInternalServerError:
+		return parseContent(&simpleErrDef{code: ErrCodeServer}, content)
+	default:
+		return &APIError{ErrCodeUnknown, "unknown error"}, nil
+	}
+}
+
+type errorDefinition interface {
+	message() string
+	errCode() int
+}
+
+func parseContent(errDef errorDefinition, content []byte) (*APIError, error) {
+	if err := json.Unmarshal(content, errDef); err != nil {
+		return nil, err
+	}
+
+	return &APIError{message: errDef.message(), ErrCode: errDef.errCode()}, nil
+}
+
+type simpleErrDef struct {
+	Message string `json:"message"`
+	code    int
+}
+
+func (def *simpleErrDef) message() string {
+	return def.Message
+}
+
+func (def *simpleErrDef) errCode() int {
+	return def.code
+}
+
+type badRequestDef struct {
+	Message string `json:"message"`
+	Details []struct {
+		Path   string   `json:"path"`
+		Errors []string `json:"errors"`
+	} `json:"details"`
+}
+
+func (def *badRequestDef) message() string {
+	var details []string
+	for _, detail := range def.Details {
+		errDesc := fmt.Sprintf("path: %s errors: %s", detail.Path,
+			strings.Join(detail.Errors, "; "))
+		details = append(details, errDesc)
+	}
+
+	return fmt.Sprintf("%s (details: [%s])", def.Message, strings.Join(details, ", "))
+}
+
+func (def *badRequestDef) errCode() int {
+	return ErrCodeBadRequest
+}
+
+type conflictDef struct {
+	Message     string `json:"message"`
+	Deployments []struct {
+		ID string `json:"id"`
+	} `json:"deployments"`
+}
+
+func (def *conflictDef) message() string {
+	if len(def.Deployments) == 0 {
+		// 409 Conflict response to "POST /v2/apps".
+		return def.Message
+	}
+
+	// 409 Conflict response to "PUT /v2/apps/{appId}".
+	var ids []string
+	for _, deployment := range def.Deployments {
+		ids = append(ids, deployment.ID)
+	}
+	return fmt.Sprintf("%s (locking deployment IDs: %s)", def.Message, strings.Join(ids, ", "))
+}
+
+func (def *conflictDef) errCode() int {
+	if len(def.Deployments) == 0 {
+		return ErrCodeDuplicateID
+	}
+
+	return ErrCodeAppLocked
+}
+
+type unprocessableEntityDef struct {
+	Message string `json:"message"`
+	Errors  []struct {
+		Attribute string `json:"attribute"`
+		Error     string `json:"error"`
+	} `json:"errors"`
+}
+
+func (def *unprocessableEntityDef) message() string {
+	var errs []string
+	for _, err := range def.Errors {
+		errs = append(errs,
+			fmt.Sprintf("attribute %s %s", err.Attribute, err.Error))
+	}
+
+	return fmt.Sprintf("%s (errors: %s)", def.Message, strings.Join(errs, ", "))
+}
+
+func (def *unprocessableEntityDef) errCode() int {
+	return ErrCodeInvalidBean
+}

--- a/error.go
+++ b/error.go
@@ -114,12 +114,12 @@ type badRequestDef struct {
 func (def *badRequestDef) message() string {
 	var details []string
 	for _, detail := range def.Details {
-		errDesc := fmt.Sprintf("path: %s errors: %s", detail.Path,
-			strings.Join(detail.Errors, "; "))
+		errDesc := fmt.Sprintf("path: '%s' errors: %s", detail.Path,
+			strings.Join(detail.Errors, ", "))
 		details = append(details, errDesc)
 	}
 
-	return fmt.Sprintf("%s (details: [%s])", def.Message, strings.Join(details, ", "))
+	return fmt.Sprintf("%s (%s)", def.Message, strings.Join(details, "; "))
 }
 
 func (def *badRequestDef) errCode() int {
@@ -167,10 +167,10 @@ func (def *unprocessableEntityDef) message() string {
 	var errs []string
 	for _, err := range def.Errors {
 		errs = append(errs,
-			fmt.Sprintf("attribute %s %s", err.Attribute, err.Error))
+			fmt.Sprintf("attribute '%s': %s", err.Attribute, err.Error))
 	}
 
-	return fmt.Sprintf("%s (errors: %s)", def.Message, strings.Join(errs, ", "))
+	return fmt.Sprintf("%s (%s)", def.Message, strings.Join(errs, "; "))
 }
 
 func (def *unprocessableEntityDef) errCode() int {

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2015 Rohith All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test400Error(t *testing.T) {
+	content := []byte(`{"message": "Invalid JSON", "details": [ {"path": "/id", "errors": ["error.expected.jsstring"] } ] }`)
+
+	e := validatedAPIError(t, http.StatusBadRequest, content, false)
+
+	assert.Equal(t, ErrCodeBadRequest, e.ErrCode)
+	assert.Contains(t, e.Error(), "Invalid JSON (details: [path: /id errors: error.expected.jsstring])")
+}
+
+func Test401Error(t *testing.T) {
+	content := []byte(`{"message": "invalid username or password."}`)
+
+	e := validatedAPIError(t, http.StatusUnauthorized, content, false)
+
+	assert.Equal(t, ErrCodeUnauthorized, e.ErrCode)
+	assert.Contains(t, e.Error(), "invalid username or password")
+}
+
+func Test403Error(t *testing.T) {
+	content := []byte(`{"message": "Not Authorized to perform this action!"}`)
+
+	e := validatedAPIError(t, http.StatusForbidden, content, false)
+
+	assert.Equal(t, ErrCodeForbidden, e.ErrCode)
+	assert.Contains(t, e.Error(), "Not Authorized to perform this action!")
+}
+
+func Test404Error(t *testing.T) {
+	content := []byte(`{"message": "App '/not_existent' does not exist"}`)
+
+	e := validatedAPIError(t, http.StatusNotFound, content, false)
+
+	assert.Equal(t, ErrCodeNotFound, e.ErrCode)
+	assert.Contains(t, e.Error(), "App '/not_existent' does not exist")
+}
+
+func Test409POSTError(t *testing.T) {
+	content := []byte(`{"message": "An app with id [/existing_app] already exists."}`)
+
+	e := validatedAPIError(t, http.StatusConflict, content, false)
+
+	assert.Equal(t, ErrCodeDuplicateID, e.ErrCode)
+	assert.Contains(t, e.Error(), "An app with id [/existing_app] already exists.")
+}
+
+func Test409PUTError(t *testing.T) {
+	content := []byte(`{"message":"App is locked", "deployments": [ { "id": "97c136bf-5a28-4821-9d94-480d9fbb01c8" } ] }`)
+
+	e := validatedAPIError(t, http.StatusConflict, content, false)
+
+	assert.Equal(t, ErrCodeAppLocked, e.ErrCode)
+	assert.Contains(t, e.Error(), "App is locked (locking deployment IDs: 97c136bf-5a28-4821-9d94-480d9fbb01c8)")
+}
+
+func Test422Error(t *testing.T) {
+	content := []byte(`{
+  "message": "Bean is not valid",
+	"errors": [
+		{
+  		"attribute": "upgradeStrategy.minimumHealthCapacity",
+    	"error": "is greater than 1"
+  	}
+	]
+}`)
+
+	e := validatedAPIError(t, 422, content, false)
+
+	assert.Equal(t, ErrCodeInvalidBean, e.ErrCode)
+	assert.Contains(t, e.Error(), "Bean is not valid (errors: attribute upgradeStrategy.minimumHealthCapacity is greater than 1)")
+}
+
+func TestServerError(t *testing.T) {
+	content := []byte(`{"message": "internal server error"}`)
+
+	for _, code := range []int{500, 501} {
+		e := validatedAPIError(t, code, content, false)
+
+		assert.Equal(t, ErrCodeServer, e.ErrCode, "code: %d", code)
+		assert.Contains(t, e.Error(), "internal server error")
+	}
+}
+
+func TestUnknownError(t *testing.T) {
+	content := []byte("unknown error")
+
+	e := validatedAPIError(t, 499, content, false)
+
+	assert.Equal(t, ErrCodeUnknown, e.ErrCode)
+	assert.Contains(t, e.Error(), "unknown error")
+}
+
+func TestInvalidJSON(t *testing.T) {
+	content := []byte{}
+	for _, code := range []int{400, 401, 403, 404, 409, 422, 500, 501} {
+		validatedAPIError(t, code, content, true)
+	}
+}
+
+func validatedAPIError(t *testing.T, code int, content []byte, parseErr bool) *APIError {
+	e, err := NewAPIError(code, content)
+	if parseErr {
+		assert.Error(t, err, "code: %d", code)
+	} else {
+		assert.NoError(t, err, "code: %d", code)
+	}
+
+	return e
+}

--- a/group.go
+++ b/group.go
@@ -90,7 +90,7 @@ func (r *marathonClient) HasGroup(name string) (bool, error) {
 	uri := fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name))
 	err := r.apiCall("GET", uri, "", nil)
 	if err != nil {
-		if err == ErrDoesNotExist {
+		if apiErr, ok := err.(*APIError); ok && apiErr.ErrCode == ErrCodeNotFound {
 			return false, nil
 		}
 		return false, err

--- a/testing_utils_test.go
+++ b/testing_utils_test.go
@@ -113,7 +113,7 @@ func newFakeMarathonEndpoint(t *testing.T, config *Config) *endpoint {
 			return
 		}
 
-		http.Error(writer, "not found", 404)
+		http.Error(writer, `{"message": "not found"}`, 404)
 	})
 
 	httpSrv := httptest.NewServer(mux)


### PR DESCRIPTION
With this change, we start to parse error responses into meaningful error instances. Error details are distinguished by means of dedicated error codes that can be evaluated easily.

Additionally, we do some cleanup and remove existing error values that were unused.

Refs #101.