### PR TITLE
Fix scaling application to zero instances

### DIFF
--- a/application.go
+++ b/application.go
@@ -464,9 +464,13 @@ func (r *marathonClient) RestartApplication(name string, force bool) (*Deploymen
 // 		instances:	the number of instances you wish to change to
 //    force: used to force the scale operation in case of blocked deployment
 func (r *marathonClient) ScaleApplicationInstances(name string, instances int, force bool) (*DeploymentID, error) {
-	changes := new(Application)
-	changes.ID = validateID(name)
-	changes.Instances = instances
+	changes := struct {
+		ID        string `json:"id"`
+		Instances int    `json:"instances"`
+	}{
+		ID:        validateID(name),
+		Instances: instances,
+	}
 	uri := fmt.Sprintf("%s/%s?force=%t", marathonAPIApps, trimRootPath(name), force)
 	deployID := new(DeploymentID)
 	if err := r.apiPut(uri, &changes, deployID); err != nil {


### PR DESCRIPTION
I noticed that the `ScaleApplicationInstances` as well as the `UpdateApplication` are not able to set the application instances to zero. This is due to the `omitempty` annotation on the `Instances` field in the `Application` struct.

I did not want to remove the omitempty from the Application struct itself, as you always would have to set the correct instance count when doing `UpdateApplication` to avoid suspending your application. Instead I just changed the `ScaleApplicationInstances` method to use an anonymous struct which does not have that annotation and also only contains the necessary fields for scaling an application. That way you have to explicitly use `ScaleApplicationInstances` if you want to suspend your application.