### PR TITLE
Fix issue with setting empty values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ language: go
 go:
   - 1.5
 install:
-  - make test
+  - make test examples

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 atheatos <atheatos.engr@gmail.com>
+Daniel Bornkessel <github@bornkessel.com>
 Denis Parchenko <denis.parchenko@gmail.com>
 Elliot Anderson <elliot.a@gmail.com>
 Harpreet Sawhney <harpreet.sawhney@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,8 @@ test: deps
 	@$(MAKE) vet
 	@$(MAKE) cover
 
+examples:
+	make -C examples all
+
 changelog: release
 	git log $(shell git tag | tail -n1)..HEAD --no-merges --format=%B > changelog

--- a/README.md
+++ b/README.md
@@ -100,17 +100,22 @@ for _, application := range applications.Apps {
 
 ```Go
 log.Printf("Deploying a new application")
-application := marathon.NewDockerApplication()
-application.Name("/product/name/frontend")
-application.CPU(0.1).Memory(64).Storage(0.0).Count(2)
-application.Arg("/usr/sbin/apache2ctl", "-D", "FOREGROUND")
-application.AddEnv("NAME", "frontend_http")
-application.AddEnv("SERVICE_80_NAME", "test_http")
-application.AddLabel("environment", "staging")
-application.AddLabel("security", "none")
-// add the docker container
-application.Container.Docker.Container("quay.io/gambol99/apache-php:latest").Expose(80, 443)
-application.CheckHTTP("/health", 10, 5)
+application := marathon.NewDockerApplication().
+  Name(applicationName).
+  CPU(0.1).
+  Memory(64).
+  Storage(0.0).
+  Count(2).
+  AddArgs("/usr/sbin/apache2ctl", "-D", "FOREGROUND").
+  AddEnv("NAME", "frontend_http").
+  AddEnv("SERVICE_80_NAME", "test_http").
+  CheckHTTP("/health", 10, 5)
+
+application.
+  Container.Docker.Container("quay.io/gambol99/apache-php:latest").
+  Bridged().
+  Expose(80).
+  Expose(443)
 
 if _, err := client.CreateApplication(application); err != nil {
 	log.Fatalf("Failed to create application: %s, error: %s", application, err)

--- a/docker_test.go
+++ b/docker_test.go
@@ -31,15 +31,31 @@ func createPortMapping(containerPort int, protocol string) *PortMapping {
 	}
 }
 
+func TestDockerAddParameter(t *testing.T) {
+	docker := NewDockerApplication().Container.Docker
+	docker.AddParameter("k1", "v1").AddParameter("k2", "v2")
+
+	assert.Equal(t, 2, len(*docker.Parameters))
+	assert.Equal(t, (*docker.Parameters)[0].Key, "k1")
+	assert.Equal(t, (*docker.Parameters)[0].Value, "v1")
+	assert.Equal(t, (*docker.Parameters)[1].Key, "k2")
+	assert.Equal(t, (*docker.Parameters)[1].Value, "v2")
+
+	docker.EmptyParameters()
+	assert.NotNil(t, docker.Parameters)
+	assert.Equal(t, 0, len(*docker.Parameters))
+}
+
 func TestDockerExpose(t *testing.T) {
 	app := NewDockerApplication()
 	app.Container.Docker.Expose(8080).Expose(80, 443)
 
 	portMappings := app.Container.Docker.PortMappings
-	assert.Equal(t, 3, len(portMappings))
-	assert.Equal(t, createPortMapping(8080, "tcp"), portMappings[0])
-	assert.Equal(t, createPortMapping(80, "tcp"), portMappings[1])
-	assert.Equal(t, createPortMapping(443, "tcp"), portMappings[2])
+	assert.Equal(t, 3, len(*portMappings))
+
+	assert.Equal(t, *createPortMapping(8080, "tcp"), (*portMappings)[0])
+	assert.Equal(t, *createPortMapping(80, "tcp"), (*portMappings)[1])
+	assert.Equal(t, *createPortMapping(443, "tcp"), (*portMappings)[2])
 }
 
 func TestDockerExposeUDP(t *testing.T) {
@@ -47,8 +63,8 @@ func TestDockerExposeUDP(t *testing.T) {
 	app.Container.Docker.ExposeUDP(53).ExposeUDP(5060, 6881)
 
 	portMappings := app.Container.Docker.PortMappings
-	assert.Equal(t, 3, len(portMappings))
-	assert.Equal(t, createPortMapping(53, "udp"), portMappings[0])
-	assert.Equal(t, createPortMapping(5060, "udp"), portMappings[1])
-	assert.Equal(t, createPortMapping(6881, "udp"), portMappings[2])
+	assert.Equal(t, 3, len(*portMappings))
+	assert.Equal(t, *createPortMapping(53, "udp"), (*portMappings)[0])
+	assert.Equal(t, *createPortMapping(5060, "udp"), (*portMappings)[1])
+	assert.Equal(t, *createPortMapping(6881, "udp"), (*portMappings)[2])
 }

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,2 @@
+all:
+	find * -type d -exec bash -exc "cd {}; go build . || kill $${PPID}" \;

--- a/examples/groups/main.go
+++ b/examples/groups/main.go
@@ -70,7 +70,7 @@ func main() {
 	frontend := marathon.NewDockerApplication()
 	frontend.Name("/product/group/frontend")
 	frontend.CPU(0.1).Memory(64).Storage(0.0).Count(2)
-	frontend.Arg("/usr/sbin/apache2ctl").Arg("-D").Arg("FOREGROUND")
+	frontend.AddArgs("/usr/sbin/apache2ctl", "-D", "FOREGROUND")
 	frontend.AddEnv("NAME", "frontend_http")
 	frontend.AddEnv("SERVICE_80_NAME", "frontend_http")
 	frontend.AddEnv("SERVICE_443_NAME", "frontend_https")

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -19,8 +19,8 @@ func main() {
 
 	app := marathon.Application{}
 	app.ID = "tasks-test"
-	app.Cmd = "sleep 60"
-	app.Instances = 3
+	app.Command("sleep 60")
+	app.Count(3)
 	fmt.Println("Creating app.")
 	// Update application will either create or update the app.
 	_, err = client.UpdateApplication(&app, false)

--- a/group.go
+++ b/group.go
@@ -134,9 +134,9 @@ func (r *marathonClient) WaitOnGroup(name string, timeout time.Duration) error {
 
 					if application.Tasks == nil {
 						allRunning = false
-					} else if len(application.Tasks) != appID.Instances {
+					} else if len(application.Tasks) != *appID.Instances {
 						allRunning = false
-					} else if application.TasksRunning != appID.Instances {
+					} else if application.TasksRunning != *appID.Instances {
 						allRunning = false
 					} else if len(application.DeploymentIDs()) > 0 {
 						allRunning = false

--- a/group_test.go
+++ b/group_test.go
@@ -59,7 +59,7 @@ func TestGroup(t *testing.T) {
 		assert.NotNil(t, app.Container)
 		assert.NotNil(t, app.Container.Docker)
 		assert.Equal(t, app.Container.Docker.Network, "BRIDGE")
-		if len(app.Container.Docker.PortMappings) <= 0 {
+		if len(*app.Container.Docker.PortMappings) <= 0 {
 			t.Fail()
 		}
 	}

--- a/health.go
+++ b/health.go
@@ -19,24 +19,49 @@ package marathon
 // HealthCheck is the definition for an application health check
 type HealthCheck struct {
 	Command                *Command `json:"command,omitempty"`
+	PortIndex              *int     `json:"portIndex,omitempty"`
+	Path                   *string  `json:"path,omitempty"`
+	MaxConsecutiveFailures *int     `json:"maxConsecutiveFailures,omitempty"`
 	Protocol               string   `json:"protocol,omitempty"`
-	Path                   string   `json:"path,omitempty"`
 	GracePeriodSeconds     int      `json:"gracePeriodSeconds,omitempty"`
 	IntervalSeconds        int      `json:"intervalSeconds,omitempty"`
-	PortIndex              int      `json:"portIndex,omitempty"`
-	MaxConsecutiveFailures int      `json:"maxConsecutiveFailures"`
 	TimeoutSeconds         int      `json:"timeoutSeconds,omitempty"`
+}
+
+//
+func (h HealthCheck) SetCommand(c Command) HealthCheck {
+	h.Command = &c
+	return h
+}
+
+func (h HealthCheck) SetPortIndex(i int) HealthCheck {
+	h.PortIndex = &i
+	return h
+}
+
+func (h HealthCheck) SetPath(p string) HealthCheck {
+	h.Path = &p
+	return h
+}
+
+func (h HealthCheck) SetMaxConsecutiveFailures(i int) HealthCheck {
+	h.MaxConsecutiveFailures = &i
+	return h
 }
 
 // NewDefaultHealthCheck creates a default application health check
 func NewDefaultHealthCheck() *HealthCheck {
+	portIndex := 0
+	path := ""
+	maxConsecutiveFailures := 3
+
 	return &HealthCheck{
 		Protocol:               "HTTP",
-		Path:                   "",
+		Path:                   &path,
+		PortIndex:              &portIndex,
+		MaxConsecutiveFailures: &maxConsecutiveFailures,
 		GracePeriodSeconds:     30,
 		IntervalSeconds:        10,
-		PortIndex:              0,
-		MaxConsecutiveFailures: 3,
 		TimeoutSeconds:         5,
 	}
 }


### PR DESCRIPTION
Make properties pointers if sending an empty value (int -> 0, string ->
"") to marathon has a semantic meaning. In order to be able to distinguish between
null-values and unset-values (see go-github blog post discussing the
same problem for go-github [0]) -- it's actually the same problem described
in gambol99/go-marathon#124 but for all^W most properties.

Instead of providing convenience functions such as
`github.String("string")` that return a pointer to a string, I added
methods that use the builder pattern'ish approach that quite a few
properties had before as well, i.e. construction looks something like:

    application := marathon.NewDockerApplication().
      Name("myapp").
      Command("/hello-world-server").
      AddEnv("PORT", "8080").
      ...
      Count(0)

    application.Container.Docker.Container("alpine-hello-world-server").
      Bridged().
      ExposePort(8080, 0, 0, "tcp").
      SetPrivileged(false).
      SetForcePullImage(false).
      Parameter("ulimit", fmt.Sprintf("nofile=%d", concern.Limits.FileMax))

There are specialized methods called for example `EmptyArgs()` to explicitly set
an array or hash to be empty (vs. omiting it, which would mean it keeps the current
value).

For consistency's sake, I renamed `Arg` -> 'AddArgs' and `Parameter` ->
`AddParameter` as this change is a breaking change anyways.

[0] https://willnorris.com/2014/05/go-rest-apis-and-pointers