### PR TITLE
Add support for force-updating an application.

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -149,15 +149,17 @@ func TestCreateApplication(t *testing.T) {
 }
 
 func TestUpdateApplication(t *testing.T) {
-	endpoint := newFakeMarathonEndpoint(t, nil)
-	defer endpoint.Close()
+	for _, force := range []bool{false, true} {
+		endpoint := newFakeMarathonEndpoint(t, nil)
+		defer endpoint.Close()
 
-	application := NewDockerApplication()
-	application.ID = "/fake_app"
-	id, err := endpoint.Client.UpdateApplication(application)
-	assert.NoError(t, err)
-	assert.Equal(t, id.DeploymentID, "83b215a6-4e26-4e44-9333-5c385eda6438")
-	assert.Equal(t, id.Version, "2014-08-26T07:37:50.462Z")
+		application := NewDockerApplication()
+		application.ID = "/fake_app"
+		id, err := endpoint.Client.UpdateApplication(application, force)
+		assert.NoError(t, err)
+		assert.Equal(t, id.DeploymentID, "83b215a6-4e26-4e44-9333-5c385eda6438")
+		assert.Equal(t, id.Version, "2014-08-26T07:37:50.462Z")
+	}
 }
 
 func TestApplications(t *testing.T) {

--- a/client.go
+++ b/client.go
@@ -49,7 +49,7 @@ type Marathon interface {
 	// delete an application
 	DeleteApplication(name string) (*DeploymentID, error)
 	// update an application in marathon
-	UpdateApplication(application *Application) (*DeploymentID, error)
+	UpdateApplication(application *Application, force bool) (*DeploymentID, error)
 	// a list of deployments on a application
 	ApplicationDeployments(name string) ([]*DeploymentID, error)
 	// scale a application

--- a/examples/tasks/main.go
+++ b/examples/tasks/main.go
@@ -23,7 +23,7 @@ func main() {
 	app.Instances = 3
 	fmt.Println("Creating app.")
 	// Update application will either create or update the app.
-	_, err = client.UpdateApplication(&app)
+	_, err = client.UpdateApplication(&app, false)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -484,6 +484,13 @@
       "deploymentId": "83b215a6-4e26-4e44-9333-5c385eda6438",
       "version": "2014-08-26T07:37:50.462Z"
     }
+- uri: /v2/apps/fake_app?force=true
+  method: PUT
+  content: |
+    {
+      "deploymentId": "83b215a6-4e26-4e44-9333-5c385eda6438",
+      "version": "2014-08-26T07:37:50.462Z"
+    }
 - uri: /v2/groups
   method: GET
   content: |


### PR DESCRIPTION
This PR adds support for force-updating an application. REST-wise, it corresponds to passing the `force=true` query parameter to the `PUT /v2/apps` request.