### PR TITLE
Add support for fetch in Application

### DIFF
--- a/application.go
+++ b/application.go
@@ -67,6 +67,7 @@ type Application struct {
 	Labels                map[string]string   `json:"labels,omitempty"`
 	AcceptedResourceRoles []string            `json:"acceptedResourceRoles,omitempty"`
 	LastTaskFailure       *LastTaskFailure    `json:"lastTaskFailure,omitempty"`
+	Fetch                 []Fetch             `json:"fetch,omitempty"`
 }
 
 // ApplicationVersions is a collection of application versions for a specific app in marathon
@@ -83,6 +84,14 @@ type ApplicationVersion struct {
 type VersionInfo struct {
 	LastScalingAt      string `json:"lastScalingAt,omitempty"`
 	LastConfigChangeAt string `json:"lastConfigChangeAt,omitempty"`
+}
+
+// Fetch will download URI before task starts
+type Fetch struct {
+	URI        string `json:"uri,omitempty"`
+	Executable bool   `json:"executable,omitempty"`
+	Extract    bool   `json:"extract,omitempty"`
+	Cache      bool   `json:"cache,omitempty"`
 }
 
 // NewDockerApplication creates a default docker application

--- a/application.go
+++ b/application.go
@@ -67,7 +67,7 @@ type Application struct {
 	Labels                map[string]string   `json:"labels,omitempty"`
 	AcceptedResourceRoles []string            `json:"acceptedResourceRoles,omitempty"`
 	LastTaskFailure       *LastTaskFailure    `json:"lastTaskFailure,omitempty"`
-	Fetch                 []Fetch             `json:"fetch,omitempty"`
+	Fetch                 []Fetch             `json:"fetch"`
 }
 
 // ApplicationVersions is a collection of application versions for a specific app in marathon
@@ -88,10 +88,10 @@ type VersionInfo struct {
 
 // Fetch will download URI before task starts
 type Fetch struct {
-	URI        string `json:"uri,omitempty"`
-	Executable bool   `json:"executable,omitempty"`
-	Extract    bool   `json:"extract,omitempty"`
-	Cache      bool   `json:"cache,omitempty"`
+	URI        string `json:"uri"`
+	Executable bool   `json:"executable"`
+	Extract    bool   `json:"extract"`
+	Cache      bool   `json:"cache"`
 }
 
 // NewDockerApplication creates a default docker application


### PR DESCRIPTION
`fetch` is the replacement for `uris` which has been deprecated since 0.15.0