### PR TITLE
Add application configuration method

### DIFF
--- a/application.go
+++ b/application.go
@@ -359,7 +359,8 @@ func (r *marathonClient) Application(name string) (*Application, error) {
 func (r *marathonClient) ApplicationByVersion(name, version string) (*Application, error) {
 	var app *Application
 
-	if err := r.apiGet(fmt.Sprintf("%s/%s/versions/%s", marathonAPIApps, trimRootPath(name), version), nil, &app); err != nil {
+	uri := fmt.Sprintf("%s/versions/%s", buildURI(name), version)
+	if err := r.apiGet(uri, nil, &app); err != nil {
 		return nil, err
 	}
 

--- a/application.go
+++ b/application.go
@@ -353,10 +353,10 @@ func (r *marathonClient) Application(name string) (*Application, error) {
 	return wrapper.Application, nil
 }
 
-// ApplicationConfiguration retrieves the application configuration from marathon
+// ApplicationByVersion retrieves the application configuration from marathon
 // 		name: 		the id used to identify the application
 // 		version:  the version of the configuration you would like to receive
-func (r *marathonClient) ApplicationConfiguration(name, version string) (*Application, error) {
+func (r *marathonClient) ApplicationByVersion(name, version string) (*Application, error) {
 	var app *Application
 
 	if err := r.apiGet(fmt.Sprintf("%s/%s/versions/%s", marathonAPIApps, trimRootPath(name), version), nil, &app); err != nil {

--- a/application.go
+++ b/application.go
@@ -353,6 +353,19 @@ func (r *marathonClient) Application(name string) (*Application, error) {
 	return wrapper.Application, nil
 }
 
+// ApplicationConfiguration retrieves the application configuration from marathon
+// 		name: 		the id used to identify the application
+// 		version:  the version of the configuration you would like to receive
+func (r *marathonClient) ApplicationConfiguration(name, version string) (*Application, error) {
+	var app *Application
+
+	if err := r.apiGet(fmt.Sprintf("%s/%s/versions/%s", marathonAPIApps, trimRootPath(name), version), nil, &app); err != nil {
+		return nil, err
+	}
+
+	return app, nil
+}
+
 // ApplicationOK validates that the application, or more appropriately it's tasks have passed all the health checks.
 // If no health checks exist, we simply return true
 // 		name: 		the id used to identify the application

--- a/application_test.go
+++ b/application_test.go
@@ -265,18 +265,22 @@ func TestApplicationOK(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestApplication(t *testing.T) {
-	endpoint := newFakeMarathonEndpoint(t, nil)
-	defer endpoint.Close()
-
-	application, err := endpoint.Client.Application(fakeAppName)
-	assert.NoError(t, err)
+func verifyApplication(application *Application, t *testing.T) {
 	assert.NotNil(t, application)
 	assert.Equal(t, application.ID, fakeAppName)
 	assert.NotNil(t, application.HealthChecks)
 	assert.NotNil(t, application.Tasks)
 	assert.Equal(t, len(application.HealthChecks), 1)
 	assert.Equal(t, len(application.Tasks), 2)
+}
+
+func TestApplication(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	application, err := endpoint.Client.Application(fakeAppName)
+	assert.NoError(t, err)
+	verifyApplication(application, t)
 
 	_, err = endpoint.Client.Application("no_such_app")
 	assert.Error(t, err)
@@ -301,10 +305,5 @@ func TestApplicationConfiguration(t *testing.T) {
 
 	application, err := endpoint.Client.ApplicationByVersion(fakeAppName, "2014-09-12T23:28:21.737Z")
 	assert.NoError(t, err)
-	assert.NotNil(t, application)
-	assert.Equal(t, application.ID, fakeAppName)
-	assert.NotNil(t, application.HealthChecks)
-	assert.NotNil(t, application.Tasks)
-	assert.Equal(t, len(application.HealthChecks), 1)
-	assert.Equal(t, len(application.Tasks), 2)
+	verifyApplication(application, t)
 }

--- a/application_test.go
+++ b/application_test.go
@@ -306,4 +306,16 @@ func TestApplicationConfiguration(t *testing.T) {
 	application, err := endpoint.Client.ApplicationByVersion(fakeAppName, "2014-09-12T23:28:21.737Z")
 	assert.NoError(t, err)
 	verifyApplication(application, t)
+
+	_, err = endpoint.Client.ApplicationByVersion(fakeAppName, "no_such_version")
+	assert.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	assert.True(t, ok)
+	assert.Equal(t, ErrCodeNotFound, apiErr.ErrCode)
+
+	_, err = endpoint.Client.ApplicationByVersion("no_such_app", "latest")
+	assert.Error(t, err)
+	apiErr, ok = err.(*APIError)
+	assert.True(t, ok)
+	assert.Equal(t, ErrCodeNotFound, apiErr.ErrCode)
 }

--- a/application_test.go
+++ b/application_test.go
@@ -294,3 +294,17 @@ func TestApplication(t *testing.T) {
 	_, ok = err.(*APIError)
 	assert.False(t, ok)
 }
+
+func TestApplicationConfiguration(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	application, err := endpoint.Client.ApplicationConfiguration(fakeAppName, "2014-09-12T23:28:21.737Z")
+	assert.NoError(t, err)
+	assert.NotNil(t, application)
+	assert.Equal(t, application.ID, fakeAppName)
+	assert.NotNil(t, application.HealthChecks)
+	assert.NotNil(t, application.Tasks)
+	assert.Equal(t, len(application.HealthChecks), 1)
+	assert.Equal(t, len(application.Tasks), 2)
+}

--- a/application_test.go
+++ b/application_test.go
@@ -299,7 +299,7 @@ func TestApplicationConfiguration(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, nil)
 	defer endpoint.Close()
 
-	application, err := endpoint.Client.ApplicationConfiguration(fakeAppName, "2014-09-12T23:28:21.737Z")
+	application, err := endpoint.Client.ApplicationByVersion(fakeAppName, "2014-09-12T23:28:21.737Z")
 	assert.NoError(t, err)
 	assert.NotNil(t, application)
 	assert.Equal(t, application.ID, fakeAppName)

--- a/client.go
+++ b/client.go
@@ -61,7 +61,7 @@ type Marathon interface {
 	// get an application by name
 	Application(name string) (*Application, error)
 	// get an application by name and version
-	ApplicationConfiguration(name, version string) (*Application, error)
+	ApplicationByVersion(name, version string) (*Application, error)
 	// wait of application
 	WaitOnApplication(name string, timeout time.Duration) error
 

--- a/client.go
+++ b/client.go
@@ -58,8 +58,10 @@ type Marathon interface {
 	RestartApplication(name string, force bool) (*DeploymentID, error)
 	// get a list of applications from marathon
 	Applications(url.Values) (*Applications, error)
-	// get a specific application
+	// get an application by name
 	Application(name string) (*Application, error)
+	// get an application by name and version
+	ApplicationConfiguration(name, version string) (*Application, error)
 	// wait of application
 	WaitOnApplication(name string, timeout time.Duration) error
 

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -235,6 +235,121 @@
     {
         "task": {"id": "fake_app.12345"}
     }
+- uri: /v2/apps/fake_app/versions/2014-09-12T23:28:21.737Z
+  method: GET
+  content: |
+    {
+        "args": null,
+        "backoffFactor": 1.15,
+        "backoffSeconds": 1,
+        "cmd": "python toggle.py $PORT0",
+        "constraints": [],
+        "container": {
+            "docker": {
+                "image": "python:3",
+                "network": "BRIDGE",
+                "portMappings": [
+                    {
+                        "containerPort": 8080,
+                        "hostPort": 0,
+                        "servicePort": 9000,
+                        "protocol": "tcp"
+                    }
+                ]
+            },
+            "type": "DOCKER",
+            "volumes": []
+        },
+        "cpus": 0.2,
+        "dependencies": [],
+        "deployments": [],
+        "disk": 0.0,
+        "env": {},
+        "executor": "",
+        "healthChecks": [
+            {
+                "command": null,
+                "gracePeriodSeconds": 5,
+                "intervalSeconds": 10,
+                "maxConsecutiveFailures": 3,
+                "path": "/health",
+                "portIndex": 0,
+                "protocol": "HTTP",
+                "timeoutSeconds": 10
+            }
+        ],
+        "id": "/fake_app",
+        "instances": 2,
+        "lastTaskFailure": {
+            "appId": "/toggle",
+            "host": "10.141.141.10",
+            "message": "Abnormal executor termination",
+            "state": "TASK_FAILED",
+            "taskId": "toggle.cc427e60-5046-11e4-9e34-56847afe9799",
+            "timestamp": "2014-09-12T23:23:41.711Z",
+            "version": "2014-09-12T23:28:21.737Z"
+        },
+        "mem": 32.0,
+        "ports": [
+            10000
+        ],
+        "requirePorts": false,
+        "storeUrls": [],
+        "tasks": [
+            {
+                "appId": "/toggle",
+                "healthCheckResults": [
+                    {
+                        "alive": true,
+                        "consecutiveFailures": 0,
+                        "firstSuccess": "2014-09-13T00:20:28.101Z",
+                        "lastFailure": null,
+                        "lastSuccess": "2014-09-13T00:25:07.506Z",
+                        "taskId": "toggle.802df2ae-3ad4-11e4-a400-56847afe9799"
+                    }
+                ],
+                "host": "10.141.141.10",
+                "id": "toggle.802df2ae-3ad4-11e4-a400-56847afe9799",
+                "ports": [
+                    31045
+                ],
+                "stagedAt": "2014-09-12T23:28:28.594Z",
+                "startedAt": "2014-09-13T00:24:46.959Z",
+                "version": "2014-09-12T23:28:21.737Z"
+            },
+            {
+                "appId": "/toggle",
+                "healthCheckResults": [
+                    {
+                        "alive": true,
+                        "consecutiveFailures": 0,
+                        "firstSuccess": "2014-09-13T00:20:28.101Z",
+                        "lastFailure": null,
+                        "lastSuccess": "2014-09-13T00:25:07.508Z",
+                        "taskId": "toggle.7c99814d-3ad4-11e4-a400-56847afe9799"
+                    }
+                ],
+                "host": "10.141.141.10",
+                "id": "toggle.7c99814d-3ad4-11e4-a400-56847afe9799",
+                "ports": [
+                    31234
+                ],
+                "stagedAt": "2014-09-12T23:28:22.587Z",
+                "startedAt": "2014-09-13T00:24:46.965Z",
+                "version": "2014-09-12T23:28:21.737Z"
+            }
+        ],
+        "tasksRunning": 2,
+        "tasksStaged": 0,
+        "upgradeStrategy": {
+            "minimumHealthCapacity": 1.0
+        },
+        "uris": [
+            "http://downloads.mesosphere.com/misc/toggle.tgz"
+        ],
+        "user": null,
+        "version": "2014-09-12T23:28:21.737Z"
+    }
 - uri: /v2/apps/fake_app
   method: GET
   content: |


### PR DESCRIPTION
This method returns a specific version of an application which can be helpful if you have running instances of application configurations which are not the current application configuration.