### PR TITLE
Use default format verb when logging example marathon.Task.

### DIFF
--- a/examples/applications/main.go
+++ b/examples/applications/main.go
@@ -56,7 +56,7 @@ func main() {
 		assert(err)
 		if details.Tasks != nil && len(details.Tasks) > 0 {
 			for _, task := range details.Tasks {
-				log.Printf("task: %s", task)
+				log.Printf("task: %v", task)
 			}
 			health, err := client.ApplicationOK(details.ID)
 			assert(err)


### PR DESCRIPTION
`marathon.Task` does not implement `String()`, so we replace %s by %v in `fmt.Printf()`. This fixes a `go vet` complain.