### PR TITLE
Fix nil dereference with empty debug log

### DIFF
--- a/client.go
+++ b/client.go
@@ -177,12 +177,17 @@ func NewClient(config Config) (Marathon, error) {
 		return nil, err
 	}
 
+	debugLogOutput := config.LogOutput
+	if debugLogOutput == nil {
+		debugLogOutput = ioutil.Discard
+	}
+
 	return &marathonClient{
 		config:     config,
 		listeners:  make(map[EventsChannel]int, 0),
 		cluster:    cluster,
 		httpClient: config.HTTPClient,
-		debugLog:   log.New(config.LogOutput, "", 0),
+		debugLog:   log.New(debugLogOutput, "", 0),
 	}, nil
 }
 


### PR DESCRIPTION
No debug log sounds like a good default instead of panicking.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x77844]

goroutine 1 [running]:
panic(0x3ce2e0, 0xc82000a120)
	/usr/local/Cellar/go/1.6/libexec/src/runtime/panic.go:464 +0x3e6
log.(*Logger).Output(0xc820082460, 0x2, 0xc82069a0f0, 0x48, 0x0, 0x0)
	/usr/local/Cellar/go/1.6/libexec/src/log/log.go:166 +0x374
log.(*Logger).Printf(0xc820082460, 0x4b66e0, 0x20, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.6/libexec/src/log/log.go:173 +0x7e
github.com/gambol99/go-marathon.(*marathonClient).apiCall(0xc8200e0000, 0x44e218, 0x3, 0xc820082500, 0x41, 0x0, 0x0, 0x3086e0, 0xc8200d88c0, 0x0, ...)
	/Users/bobrik/projects/zoidberg/src/github.com/gambol99/go-marathon/client.go:262 +0xf98
github.com/gambol99/go-marathon.(*marathonClient).apiGet(0xc8200e0000, 0xc820082500, 0x41, 0x0, 0x0, 0x3086e0, 0xc8200d88c0, 0x0, 0x0)
	/Users/bobrik/projects/zoidberg/src/github.com/gambol99/go-marathon/client.go:203 +0x91
```