### PR TITLE
Repointerize maps and slices

### DIFF
--- a/application.go
+++ b/application.go
@@ -38,14 +38,14 @@ type Applications struct {
 type Application struct {
 	ID                    string              `json:"id,omitempty"`
 	Cmd                   *string             `json:"cmd,omitempty"`
-	Args                  []string            `json:"args,omitempty"`
-	Constraints           [][]string          `json:"constraints,omitempty"`
+	Args                  *[]string           `json:"args,omitempty"`
+	Constraints           *[][]string         `json:"constraints,omitempty"`
 	Container             *Container          `json:"container,omitempty"`
 	CPUs                  float64             `json:"cpus,omitempty"`
 	Disk                  *float64            `json:"disk,omitempty"`
-	Env                   map[string]string   `json:"env,omitempty"`
+	Env                   *map[string]string  `json:"env,omitempty"`
 	Executor              *string             `json:"executor,omitempty"`
-	HealthChecks          []HealthCheck       `json:"healthChecks,omitempty"`
+	HealthChecks          *[]HealthCheck      `json:"healthChecks,omitempty"`
 	Instances             *int                `json:"instances,omitempty"`
 	Mem                   *float64            `json:"mem,omitempty"`
 	Tasks                 []*Task             `json:"tasks,omitempty"`
@@ -62,10 +62,10 @@ type Application struct {
 	TasksUnhealthy        int                 `json:"tasksUnhealthy,omitempty"`
 	User                  string              `json:"user,omitempty"`
 	UpgradeStrategy       *UpgradeStrategy    `json:"upgradeStrategy,omitempty"`
-	Uris                  []string            `json:"uris"`
+	Uris                  *[]string           `json:"uris"`
 	Version               string              `json:"version,omitempty"`
 	VersionInfo           *VersionInfo        `json:"versionInfo,omitempty"`
-	Labels                map[string]string   `json:"labels,omitempty"`
+	Labels                *map[string]string  `json:"labels,omitempty"`
 	AcceptedResourceRoles []string            `json:"acceptedResourceRoles,omitempty"`
 	LastTaskFailure       *LastTaskFailure    `json:"lastTaskFailure,omitempty"`
 	Fetch                 []Fetch             `json:"fetch"`
@@ -176,7 +176,13 @@ func (r *Application) Count(count int) *Application {
 // AddArgs adds one or more arguments to the applications
 //		arguments:	the argument(s) you are adding
 func (r *Application) AddArgs(arguments ...string) *Application {
-	r.Args = append(r.Args, arguments...)
+	if r.Args == nil {
+		r.EmptyArgs()
+	}
+
+	args := *r.Args
+	args = append(args, arguments...)
+	r.Args = &args
 
 	return r
 }
@@ -185,15 +191,21 @@ func (r *Application) AddArgs(arguments ...string) *Application {
 // arguments of an application that already has arguments set (setting args to nil will
 // keep the current value)
 func (r *Application) EmptyArgs() *Application {
-	r.Args = []string{}
+	r.Args = &[]string{}
 
 	return r
 }
 
 // AddConstraint adds a new constraint
-//		constraints:	the constraint definition, one constraint per array element
-func (r *Application) AddConstraint(constraints ...string) *Application {
-	r.Constraints = append(r.Constraints, constraints)
+//		arguments:	the constraint definition, one argument per array element
+func (r *Application) AddConstraint(arguments ...string) *Application {
+	if r.Constraints == nil {
+		r.EmptyConstraints()
+	}
+
+	constraints := *r.Constraints
+	constraints = append(constraints, arguments)
+	r.Constraints = &constraints
 
 	return r
 }
@@ -202,7 +214,7 @@ func (r *Application) AddConstraint(constraints ...string) *Application {
 // constraints of an application that already has constraints set (setting constraints to nil will
 // keep the current value)
 func (r *Application) EmptyConstraints() *Application {
-	r.Constraints = [][]string{}
+	r.Constraints = &[][]string{}
 
 	return r
 }
@@ -212,18 +224,18 @@ func (r *Application) EmptyConstraints() *Application {
 //		value: value for this label
 func (r *Application) AddLabel(name, value string) *Application {
 	if r.Labels == nil {
-		r.EmptyLabels()
+		r.EmptyLabel()
 	}
-	r.Labels[name] = value
+	(*r.Labels)[name] = value
 
 	return r
 }
 
-// EmptyLabels explicitly empties the labels -- use this if you need to empty
+// EmptyLabel explicitly empties the labels -- use this if you need to empty
 // the labels of an application that already has labels set (setting labels to nil will
 // keep the current value)
-func (r *Application) EmptyLabels() *Application {
-	r.Labels = map[string]string{}
+func (r *Application) EmptyLabel() *Application {
+	r.Labels = &map[string]string{}
 
 	return r
 }
@@ -233,18 +245,18 @@ func (r *Application) EmptyLabels() *Application {
 //		value:	go figure, the value associated to the above
 func (r *Application) AddEnv(name, value string) *Application {
 	if r.Env == nil {
-		r.EmptyEnvs()
+		r.EmptyEnv()
 	}
-	r.Env[name] = value
+	(*r.Env)[name] = value
 
 	return r
 }
 
-// EmptyEnvs explicitly empties the envs -- use this if you need to empty
-// the environments of an application that already has environments set (setting env to nil will
+// EmptyEnv explicitly empties the env -- use this if you need to empty
+// the environment of an application that already has an environment set (setting env to nil will
 // keep the current value)
-func (r *Application) EmptyEnvs() *Application {
-	r.Env = map[string]string{}
+func (r *Application) EmptyEnv() *Application {
+	r.Env = &map[string]string{}
 
 	return r
 }
@@ -257,31 +269,39 @@ func (r *Application) SetExecutor(executor string) *Application {
 }
 
 // AddHealthCheck adds a health check
-// 	healtCheck the health check that should be added
+// 	healtchecks the health check that should be added
 func (r *Application) AddHealthCheck(healthCheck HealthCheck) *Application {
-	r.HealthChecks = append(r.HealthChecks, healthCheck)
+	if r.HealthChecks == nil {
+		r.EmptyHealthChecks()
+	}
+
+	healthChecks := *r.HealthChecks
+	healthChecks = append(healthChecks, healthCheck)
+	r.HealthChecks = &healthChecks
 
 	return r
 }
 
-// EmptyHealthChecks explicitly empties health checks -- use this if you need to empty
-// health checks of an application that already has health checks set (setting health checks to nil will
+// EmptyHealthChecks explicitly empties healthChecks -- use this if you need to empty
+// healthChecks of an application that already has healthChecks set (setting healthChecks to nil will
 // keep the current value)
 func (r *Application) EmptyHealthChecks() *Application {
-	r.HealthChecks = []HealthCheck{}
+	r.HealthChecks = &[]HealthCheck{}
 
 	return r
 }
 
-// HasHealthChecks is a helper method, used to check if an application has health checks
+// HasHealthChecks is a helper method, used to check if an application has healtchecks
 func (r *Application) HasHealthChecks() bool {
-	return len(r.HealthChecks) > 0
+	return r.HealthChecks != nil && len(*r.HealthChecks) > 0
 }
 
 // DeploymentIDs retrieves the application deployments IDs
 func (r *Application) DeploymentIDs() []*DeploymentID {
 	var deployments []*DeploymentID
-
+	if r.Deployments == nil || len(r.Deployments) <= 0 {
+		return deployments
+	}
 	// step: extract the deployment id from the result
 	for _, deploy := range r.Deployments {
 		if id, found := deploy["id"]; found {
@@ -344,7 +364,13 @@ func (r *Application) CheckTCP(port, interval int) (*Application, error) {
 // AddUris adds one or more uris to the applications
 //		arguments:	the uri(s) you are adding
 func (r *Application) AddUris(newUris ...string) *Application {
-	r.Uris = append(r.Uris, newUris...)
+	if r.Uris == nil {
+		r.EmptyUris()
+	}
+
+	uris := *r.Uris
+	uris = append(uris, newUris...)
+	r.Uris = &uris
 
 	return r
 }
@@ -353,7 +379,7 @@ func (r *Application) AddUris(newUris ...string) *Application {
 // uris of an application that already has uris set (setting uris to nil will
 // keep the current value)
 func (r *Application) EmptyUris() *Application {
-	r.Uris = []string{}
+	r.Uris = &[]string{}
 
 	return r
 }
@@ -474,16 +500,18 @@ func (r *marathonClient) ApplicationOK(name string) (bool, error) {
 	}
 
 	// step: if the application has not health checks, just return true
-	if len(application.HealthChecks) == 0 {
+	if application.HealthChecks == nil || len(*application.HealthChecks) <= 0 {
 		return true, nil
 	}
 
 	// step: iterate the application checks and look for false
 	for _, task := range application.Tasks {
-		for _, check := range task.HealthCheckResults {
-			//When a task is flapping in Marathon, this is sometimes nil
-			if check == nil || !check.Alive {
-				return false, nil
+		if task.HealthCheckResults != nil {
+			for _, check := range task.HealthCheckResults {
+				//When a task is flapping in Marathon, this is sometimes nil
+				if check == nil || !check.Alive {
+					return false, nil
+				}
 			}
 		}
 	}

--- a/application.go
+++ b/application.go
@@ -197,15 +197,15 @@ func (r *Application) EmptyArgs() *Application {
 }
 
 // AddConstraint adds a new constraint
-//		arguments:	the constraint definition, one argument per array element
-func (r *Application) AddConstraint(arguments ...string) *Application {
+//		constraints:	the constraint definition, one constraint per array element
+func (r *Application) AddConstraint(constraints ...string) *Application {
 	if r.Constraints == nil {
 		r.EmptyConstraints()
 	}
 
-	constraints := *r.Constraints
-	constraints = append(constraints, arguments)
-	r.Constraints = &constraints
+	c := *r.Constraints
+	c = append(c, constraints)
+	r.Constraints = &c
 
 	return r
 }
@@ -224,17 +224,17 @@ func (r *Application) EmptyConstraints() *Application {
 //		value: value for this label
 func (r *Application) AddLabel(name, value string) *Application {
 	if r.Labels == nil {
-		r.EmptyLabel()
+		r.EmptyLabels()
 	}
 	(*r.Labels)[name] = value
 
 	return r
 }
 
-// EmptyLabel explicitly empties the labels -- use this if you need to empty
+// EmptyLabels explicitly empties the labels -- use this if you need to empty
 // the labels of an application that already has labels set (setting labels to nil will
 // keep the current value)
-func (r *Application) EmptyLabel() *Application {
+func (r *Application) EmptyLabels() *Application {
 	r.Labels = &map[string]string{}
 
 	return r
@@ -245,17 +245,17 @@ func (r *Application) EmptyLabel() *Application {
 //		value:	go figure, the value associated to the above
 func (r *Application) AddEnv(name, value string) *Application {
 	if r.Env == nil {
-		r.EmptyEnv()
+		r.EmptyEnvs()
 	}
 	(*r.Env)[name] = value
 
 	return r
 }
 
-// EmptyEnv explicitly empties the env -- use this if you need to empty
-// the environment of an application that already has an environment set (setting env to nil will
+// EmptyEnvs explicitly empties the envs -- use this if you need to empty
+// the environments of an application that already has environments set (setting env to nil will
 // keep the current value)
-func (r *Application) EmptyEnv() *Application {
+func (r *Application) EmptyEnvs() *Application {
 	r.Env = &map[string]string{}
 
 	return r
@@ -269,7 +269,7 @@ func (r *Application) SetExecutor(executor string) *Application {
 }
 
 // AddHealthCheck adds a health check
-// 	healtchecks the health check that should be added
+// 	healthCheck the health check that should be added
 func (r *Application) AddHealthCheck(healthCheck HealthCheck) *Application {
 	if r.HealthChecks == nil {
 		r.EmptyHealthChecks()
@@ -282,8 +282,8 @@ func (r *Application) AddHealthCheck(healthCheck HealthCheck) *Application {
 	return r
 }
 
-// EmptyHealthChecks explicitly empties healthChecks -- use this if you need to empty
-// healthChecks of an application that already has healthChecks set (setting healthChecks to nil will
+// EmptyHealthChecks explicitly empties health checks -- use this if you need to empty
+// health checks of an application that already has health checks set (setting health checks to nil will
 // keep the current value)
 func (r *Application) EmptyHealthChecks() *Application {
 	r.HealthChecks = &[]HealthCheck{}
@@ -291,7 +291,7 @@ func (r *Application) EmptyHealthChecks() *Application {
 	return r
 }
 
-// HasHealthChecks is a helper method, used to check if an application has healtchecks
+// HasHealthChecks is a helper method, used to check if an application has health checks
 func (r *Application) HasHealthChecks() bool {
 	return r.HealthChecks != nil && len(*r.HealthChecks) > 0
 }
@@ -299,9 +299,11 @@ func (r *Application) HasHealthChecks() bool {
 // DeploymentIDs retrieves the application deployments IDs
 func (r *Application) DeploymentIDs() []*DeploymentID {
 	var deployments []*DeploymentID
-	if r.Deployments == nil || len(r.Deployments) <= 0 {
+
+	if r.Deployments == nil {
 		return deployments
 	}
+
 	// step: extract the deployment id from the result
 	for _, deploy := range r.Deployments {
 		if id, found := deploy["id"]; found {
@@ -500,18 +502,16 @@ func (r *marathonClient) ApplicationOK(name string) (bool, error) {
 	}
 
 	// step: if the application has not health checks, just return true
-	if application.HealthChecks == nil || len(*application.HealthChecks) <= 0 {
+	if application.HealthChecks == nil || len(*application.HealthChecks) == 0 {
 		return true, nil
 	}
 
 	// step: iterate the application checks and look for false
 	for _, task := range application.Tasks {
-		if task.HealthCheckResults != nil {
-			for _, check := range task.HealthCheckResults {
-				//When a task is flapping in Marathon, this is sometimes nil
-				if check == nil || !check.Alive {
-					return false, nil
-				}
+		for _, check := range task.HealthCheckResults {
+			//When a task is flapping in Marathon, this is sometimes nil
+			if check == nil || !check.Alive {
+				return false, nil
 			}
 		}
 	}

--- a/application_test.go
+++ b/application_test.go
@@ -142,7 +142,7 @@ func TestApplicationLabels(t *testing.T) {
 	assert.Equal(t, "world", (*app.Labels)["hello"])
 	assert.Equal(t, "bar", (*app.Labels)["foo"])
 
-	app.EmptyLabel()
+	app.EmptyLabels()
 	assert.NotNil(t, app.Labels)
 	assert.Equal(t, 0, len(*app.Labels))
 }
@@ -156,7 +156,7 @@ func TestApplicationEnvs(t *testing.T) {
 	assert.Equal(t, "world", (*app.Env)["hello"])
 	assert.Equal(t, "bar", (*app.Env)["foo"])
 
-	app.EmptyEnv()
+	app.EmptyEnvs()
 	assert.NotNil(t, app.Env)
 	assert.Equal(t, 0, len(*app.Env))
 }

--- a/application_test.go
+++ b/application_test.go
@@ -100,14 +100,14 @@ func TestApplicationArgs(t *testing.T) {
 	app := NewDockerApplication()
 	assert.Nil(t, app.Args)
 	app.AddArgs("-p").AddArgs("option", "-v")
-	assert.Equal(t, 3, len(app.Args))
-	assert.Equal(t, "-p", app.Args[0])
-	assert.Equal(t, "option", app.Args[1])
-	assert.Equal(t, "-v", app.Args[2])
+	assert.Equal(t, 3, len(*app.Args))
+	assert.Equal(t, "-p", (*app.Args)[0])
+	assert.Equal(t, "option", (*app.Args)[1])
+	assert.Equal(t, "-v", (*app.Args)[2])
 
 	app.EmptyArgs()
 	assert.NotNil(t, app.Args)
-	assert.Equal(t, 0, len(app.Args))
+	assert.Equal(t, 0, len(*app.Args))
 }
 
 func ExampleApplication_AddConstraint() {
@@ -124,13 +124,13 @@ func TestApplicationConstraints(t *testing.T) {
 	app.AddConstraint("hostname", "UNIQUE").
 		AddConstraint("rack_id", "CLUSTER", "rack-1")
 
-	assert.Equal(t, 2, len(app.Constraints))
-	assert.Equal(t, []string{"hostname", "UNIQUE"}, app.Constraints[0])
-	assert.Equal(t, []string{"rack_id", "CLUSTER", "rack-1"}, app.Constraints[1])
+	assert.Equal(t, 2, len(*app.Constraints))
+	assert.Equal(t, []string{"hostname", "UNIQUE"}, (*app.Constraints)[0])
+	assert.Equal(t, []string{"rack_id", "CLUSTER", "rack-1"}, (*app.Constraints)[1])
 
 	app.EmptyConstraints()
 	assert.NotNil(t, app.Constraints)
-	assert.Equal(t, 0, len(app.Constraints))
+	assert.Equal(t, 0, len(*app.Constraints))
 }
 
 func TestApplicationLabels(t *testing.T) {
@@ -138,13 +138,13 @@ func TestApplicationLabels(t *testing.T) {
 	assert.Nil(t, app.Labels)
 
 	app.AddLabel("hello", "world").AddLabel("foo", "bar")
-	assert.Equal(t, 2, len(app.Labels))
-	assert.Equal(t, "world", app.Labels["hello"])
-	assert.Equal(t, "bar", app.Labels["foo"])
+	assert.Equal(t, 2, len(*app.Labels))
+	assert.Equal(t, "world", (*app.Labels)["hello"])
+	assert.Equal(t, "bar", (*app.Labels)["foo"])
 
-	app.EmptyLabels()
+	app.EmptyLabel()
 	assert.NotNil(t, app.Labels)
-	assert.Equal(t, 0, len(app.Labels))
+	assert.Equal(t, 0, len(*app.Labels))
 }
 
 func TestApplicationEnvs(t *testing.T) {
@@ -152,13 +152,13 @@ func TestApplicationEnvs(t *testing.T) {
 	assert.Nil(t, app.Env)
 
 	app.AddEnv("hello", "world").AddEnv("foo", "bar")
-	assert.Equal(t, 2, len(app.Env))
-	assert.Equal(t, "world", (app.Env)["hello"])
-	assert.Equal(t, "bar", (app.Env)["foo"])
+	assert.Equal(t, 2, len(*app.Env))
+	assert.Equal(t, "world", (*app.Env)["hello"])
+	assert.Equal(t, "bar", (*app.Env)["foo"])
 
-	app.EmptyEnvs()
+	app.EmptyEnv()
 	assert.NotNil(t, app.Env)
-	assert.Equal(t, 0, len(app.Env))
+	assert.Equal(t, 0, len(*app.Env))
 }
 
 func TestApplicationSetExecutor(t *testing.T) {
@@ -178,13 +178,13 @@ func TestApplicationHealthChecks(t *testing.T) {
 	app.AddHealthCheck(HealthCheck{}.SetPath("/check1")).
 		AddHealthCheck(HealthCheck{}.SetPath("/check2"))
 
-	assert.Equal(t, 2, len(app.HealthChecks))
-	assert.Equal(t, HealthCheck{}.SetPath("/check1"), app.HealthChecks[0])
-	assert.Equal(t, HealthCheck{}.SetPath("/check2"), app.HealthChecks[1])
+	assert.Equal(t, 2, len(*app.HealthChecks))
+	assert.Equal(t, HealthCheck{}.SetPath("/check1"), (*app.HealthChecks)[0])
+	assert.Equal(t, HealthCheck{}.SetPath("/check2"), (*app.HealthChecks)[1])
 
 	app.EmptyHealthChecks()
 	assert.NotNil(t, app.HealthChecks)
-	assert.Equal(t, 0, len(app.HealthChecks))
+	assert.Equal(t, 0, len(*app.HealthChecks))
 }
 
 func TestHasHealthChecks(t *testing.T) {
@@ -206,7 +206,7 @@ func TestApplicationCheckTCP(t *testing.T) {
 	_, err = app.CheckTCP(80, 10)
 	assert.NoError(t, err)
 	assert.True(t, app.HasHealthChecks())
-	check := app.HealthChecks[0]
+	check := (*app.HealthChecks)[0]
 	assert.Equal(t, "TCP", check.Protocol)
 	assert.Equal(t, 10, check.IntervalSeconds)
 	assert.Equal(t, 0, *check.PortIndex)
@@ -222,7 +222,7 @@ func TestApplicationCheckHTTP(t *testing.T) {
 	_, err = app.CheckHTTP("/health", 80, 10)
 	assert.NoError(t, err)
 	assert.True(t, app.HasHealthChecks())
-	check := app.HealthChecks[0]
+	check := (*app.HealthChecks)[0]
 	assert.Equal(t, "HTTP", check.Protocol)
 	assert.Equal(t, 10, check.IntervalSeconds)
 	assert.Equal(t, "/health", *check.Path)
@@ -311,14 +311,14 @@ func TestApplicationUris(t *testing.T) {
 	app := NewDockerApplication()
 	assert.Nil(t, app.Uris)
 	app.AddUris("file://uri1.tar.gz").AddUris("file://uri2.tar.gz", "file://uri3.tar.gz")
-	assert.Equal(t, 3, len(app.Uris))
-	assert.Equal(t, "file://uri1.tar.gz", app.Uris[0])
-	assert.Equal(t, "file://uri2.tar.gz", app.Uris[1])
-	assert.Equal(t, "file://uri3.tar.gz", app.Uris[2])
+	assert.Equal(t, 3, len(*app.Uris))
+	assert.Equal(t, "file://uri1.tar.gz", (*app.Uris)[0])
+	assert.Equal(t, "file://uri2.tar.gz", (*app.Uris)[1])
+	assert.Equal(t, "file://uri3.tar.gz", (*app.Uris)[2])
 
 	app.EmptyUris()
 	assert.NotNil(t, app.Uris)
-	assert.Equal(t, 0, len(app.Uris))
+	assert.Equal(t, 0, len(*app.Uris))
 }
 
 func TestSetApplicationVersion(t *testing.T) {
@@ -378,7 +378,7 @@ func verifyApplication(application *Application, t *testing.T) {
 	assert.Equal(t, application.ID, fakeAppName)
 	assert.NotNil(t, application.HealthChecks)
 	assert.NotNil(t, application.Tasks)
-	assert.Equal(t, len(application.HealthChecks), 1)
+	assert.Equal(t, len(*application.HealthChecks), 1)
 	assert.Equal(t, len(application.Tasks), 2)
 }
 

--- a/docker.go
+++ b/docker.go
@@ -85,7 +85,6 @@ func (container *Container) Volume(hostPath, containerPath, mode string) *Contai
 // keep the current value)
 func (container *Container) EmptyVolumes() *Container {
 	container.Volumes = &[]Volume{}
-
 	return container
 }
 
@@ -172,8 +171,7 @@ func (docker *Docker) ExposePort(containerPort, hostPort, servicePort int, proto
 // port mappings of an application that already has port mappings set (setting port mappings to nil will
 // keep the current value)
 func (docker *Docker) EmptyPortMappings() *Docker {
-	empty := []PortMapping{}
-	docker.PortMappings = &empty
+	docker.PortMappings = &[]PortMapping{}
 	return docker
 }
 
@@ -199,15 +197,14 @@ func (docker *Docker) AddParameter(key string, value string) *Docker {
 // parameters of an application that already has parameters set (setting parameters to nil will
 // keep the current value)
 func (docker *Docker) EmptyParameters() *Docker {
-	empty := []Parameters{}
-	docker.Parameters = &empty
+	docker.Parameters = &[]Parameters{}
 	return docker
 }
 
 // ServicePortIndex finds the service port index of the exposed port
 //		port:			the port you are looking for
 func (docker *Docker) ServicePortIndex(port int) (int, error) {
-	if docker.PortMappings == nil || len(*docker.PortMappings) <= 0 {
+	if docker.PortMappings == nil || len(*docker.PortMappings) == 0 {
 		return 0, errors.New("The docker does not contain any port mappings to search")
 	}
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -35,15 +35,15 @@ func TestDockerAddParameter(t *testing.T) {
 	docker := NewDockerApplication().Container.Docker
 	docker.AddParameter("k1", "v1").AddParameter("k2", "v2")
 
-	assert.Equal(t, 2, len(docker.Parameters))
-	assert.Equal(t, docker.Parameters[0].Key, "k1")
-	assert.Equal(t, docker.Parameters[0].Value, "v1")
-	assert.Equal(t, docker.Parameters[1].Key, "k2")
-	assert.Equal(t, docker.Parameters[1].Value, "v2")
+	assert.Equal(t, 2, len(*docker.Parameters))
+	assert.Equal(t, (*docker.Parameters)[0].Key, "k1")
+	assert.Equal(t, (*docker.Parameters)[0].Value, "v1")
+	assert.Equal(t, (*docker.Parameters)[1].Key, "k2")
+	assert.Equal(t, (*docker.Parameters)[1].Value, "v2")
 
 	docker.EmptyParameters()
 	assert.NotNil(t, docker.Parameters)
-	assert.Equal(t, 0, len(docker.Parameters))
+	assert.Equal(t, 0, len(*docker.Parameters))
 }
 
 func TestDockerExpose(t *testing.T) {
@@ -51,11 +51,11 @@ func TestDockerExpose(t *testing.T) {
 	app.Container.Docker.Expose(8080).Expose(80, 443)
 
 	portMappings := app.Container.Docker.PortMappings
-	assert.Equal(t, 3, len(portMappings))
+	assert.Equal(t, 3, len(*portMappings))
 
-	assert.Equal(t, *createPortMapping(8080, "tcp"), portMappings[0])
-	assert.Equal(t, *createPortMapping(80, "tcp"), portMappings[1])
-	assert.Equal(t, *createPortMapping(443, "tcp"), portMappings[2])
+	assert.Equal(t, *createPortMapping(8080, "tcp"), (*portMappings)[0])
+	assert.Equal(t, *createPortMapping(80, "tcp"), (*portMappings)[1])
+	assert.Equal(t, *createPortMapping(443, "tcp"), (*portMappings)[2])
 }
 
 func TestDockerExposeUDP(t *testing.T) {
@@ -63,8 +63,8 @@ func TestDockerExposeUDP(t *testing.T) {
 	app.Container.Docker.ExposeUDP(53).ExposeUDP(5060, 6881)
 
 	portMappings := app.Container.Docker.PortMappings
-	assert.Equal(t, 3, len(portMappings))
-	assert.Equal(t, *createPortMapping(53, "udp"), portMappings[0])
-	assert.Equal(t, *createPortMapping(5060, "udp"), portMappings[1])
-	assert.Equal(t, *createPortMapping(6881, "udp"), portMappings[2])
+	assert.Equal(t, 3, len(*portMappings))
+	assert.Equal(t, *createPortMapping(53, "udp"), (*portMappings)[0])
+	assert.Equal(t, *createPortMapping(5060, "udp"), (*portMappings)[1])
+	assert.Equal(t, *createPortMapping(6881, "udp"), (*portMappings)[2])
 }

--- a/group_test.go
+++ b/group_test.go
@@ -59,7 +59,7 @@ func TestGroup(t *testing.T) {
 		assert.NotNil(t, app.Container)
 		assert.NotNil(t, app.Container.Docker)
 		assert.Equal(t, app.Container.Docker.Network, "BRIDGE")
-		if len(app.Container.Docker.PortMappings) == 0 {
+		if len(*app.Container.Docker.PortMappings) <= 0 {
 			t.Fail()
 		}
 	}

--- a/group_test.go
+++ b/group_test.go
@@ -59,7 +59,7 @@ func TestGroup(t *testing.T) {
 		assert.NotNil(t, app.Container)
 		assert.NotNil(t, app.Container.Docker)
 		assert.Equal(t, app.Container.Docker.Network, "BRIDGE")
-		if len(*app.Container.Docker.PortMappings) <= 0 {
+		if len(*app.Container.Docker.PortMappings) == 0 {
 			t.Fail()
 		}
 	}

--- a/task.go
+++ b/task.go
@@ -176,7 +176,7 @@ func (r *marathonClient) TaskEndpoints(name string, port int, healthCheck bool) 
 	}
 
 	// step: do we have any tasks?
-	if application.Tasks == nil || len(application.Tasks) <= 0 {
+	if application.Tasks == nil || len(application.Tasks) == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Revert what was done in #138 as it would not work due to the fact that `encoding/json` drops empty reference types on `omitempty` too.

We keep our cosmetics changes though.

Refs #137.