### PR TITLE
Add SlaveID field in Task struct

### DIFF
--- a/task.go
+++ b/task.go
@@ -34,6 +34,7 @@ type Task struct {
 	HealthCheckResults []*HealthCheckResult `json:"healthCheckResults"`
 	Ports              []int                `json:"ports"`
 	ServicePorts       []int                `json:"servicePorts"`
+	SlaveID            string               `json:"slaveId"`
 	StagedAt           string               `json:"stagedAt"`
 	StartedAt          string               `json:"startedAt"`
 	Version            string               `json:"version"`


### PR DESCRIPTION
Marathon has a "slaveId" field in "task" since v0.11.0-RC1