### PR TITLE
marathon task.Ipaddresses field added

### DIFF
--- a/events.go
+++ b/events.go
@@ -129,15 +129,16 @@ type EventAPIRequest struct {
 
 // EventStatusUpdate describes a 'status_update_event' event.
 type EventStatusUpdate struct {
-	EventType  string `json:"eventType"`
-	Timestamp  string `json:"timestamp,omitempty"`
-	SlaveID    string `json:"slaveId,omitempty"`
-	TaskID     string `json:"taskId"`
-	TaskStatus string `json:"taskStatus"`
-	AppID      string `json:"appId"`
-	Host       string `json:"host"`
-	Ports      []int  `json:"ports,omitempty"`
-	Version    string `json:"version,omitempty"`
+	EventType   string       `json:"eventType"`
+	Timestamp   string       `json:"timestamp,omitempty"`
+	SlaveID     string       `json:"slaveId,omitempty"`
+	TaskID      string       `json:"taskId"`
+	TaskStatus  string       `json:"taskStatus"`
+	AppID       string       `json:"appId"`
+	Host        string       `json:"host"`
+	Ports       []int        `json:"ports,omitempty"`
+	IPAddresses []*IPAddress `json:"ipAddresses"`
+	Version     string       `json:"version,omitempty"`
 }
 
 // EventAppTerminated describes an 'app_terminated_event' event.

--- a/task.go
+++ b/task.go
@@ -37,7 +37,13 @@ type Task struct {
 	SlaveID            string               `json:"slaveId"`
 	StagedAt           string               `json:"stagedAt"`
 	StartedAt          string               `json:"startedAt"`
+	IPAddresses        []*IPAddress         `json:"ipAddresses"`
 	Version            string               `json:"version"`
+}
+
+type IPAddress struct {
+	IPAddress string `json:"ipAddress"`
+	Protocol  string `json:"protocol"`
 }
 
 // AllTasksOpts contains a payload for AllTasks method


### PR DESCRIPTION
Good day,
since marathon version 1.1.1 additional field in Task structure has been introduced.
It look like this.
`            
"ipAddresses": [
                {
                    "ipAddress": "0.0.0.0",
                    "protocol": "IPv4"
                }
            ]
`