### PR TITLE
Issue111: KillTask does not work if AppID has hierarchical path

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -24,8 +24,8 @@ import (
 
 func TestApplicationDependsOn(t *testing.T) {
 	app := NewDockerApplication()
-	app.DependsOn("fake_app")
-	app.DependsOn("fake_app1", "fake_app2")
+	app.DependsOn("fake-app")
+	app.DependsOn("fake-app1", "fake-app2")
 	assert.Equal(t, 3, len(app.Dependencies))
 }
 
@@ -234,11 +234,11 @@ func TestCreateApplication(t *testing.T) {
 	defer endpoint.Close()
 
 	application := NewDockerApplication()
-	application.Name("/fake_app")
+	application.Name(fakeAppName)
 	app, err := endpoint.Client.CreateApplication(application)
 	assert.NoError(t, err)
 	assert.NotNil(t, app)
-	assert.Equal(t, application.ID, "/fake_app")
+	assert.Equal(t, application.ID, fakeAppName)
 	assert.Equal(t, app.Deployments[0]["id"], "f44fd4fc-4330-4600-a68b-99c7bd33014a")
 }
 
@@ -248,7 +248,7 @@ func TestUpdateApplication(t *testing.T) {
 		defer endpoint.Close()
 
 		application := NewDockerApplication()
-		application.Name("/fake_app")
+		application.Name(fakeAppName)
 		id, err := endpoint.Client.UpdateApplication(application, force)
 		assert.NoError(t, err)
 		assert.Equal(t, id.DeploymentID, "83b215a6-4e26-4e44-9333-5c385eda6438")

--- a/task.go
+++ b/task.go
@@ -116,6 +116,9 @@ func (r *marathonClient) KillApplicationTasks(id string, opts *KillApplicationTa
 //	opts:		KillTaskOpts request payload
 func (r *marathonClient) KillTask(taskID string, opts *KillTaskOpts) (*Task, error) {
 	appName := taskID[0:strings.LastIndex(taskID, ".")]
+	appName = strings.Replace(appName, "_", "/", -1)
+	taskID = strings.Replace(taskID, "/", "_", -1)
+
 	u := fmt.Sprintf("%s/%s/tasks/%s", marathonAPIApps, appName, taskID)
 	u, err := addOptions(u, opts)
 	if err != nil {

--- a/task_test.go
+++ b/task_test.go
@@ -67,13 +67,21 @@ func TestKillApplicationTasks(t *testing.T) {
 }
 
 func TestKillTask(t *testing.T) {
+	cases := map[string]struct {
+		TaskID string
+		Result string
+	}{
+		"CommonApp":           {fakeTaskID, fakeTaskID},
+		"GroupApp":            {"fake-group_fake-app.fake-task", "fake-group_fake-app.fake-task"},
+		"GroupAppWithSlashes": {"fake-group/fake-app.fake-task", "fake-group_fake-app.fake-task"},
+	}
 	endpoint := newFakeMarathonEndpoint(t, nil)
 	defer endpoint.Close()
 
-	task, err := endpoint.Client.KillTask(fakeTaskID, nil)
-	assert.NoError(t, err)
-	if assert.NotNil(t, task) {
-		assert.Equal(t, fakeTaskID, task.ID)
+	for k, tc := range cases {
+		task, err := endpoint.Client.KillTask(tc.TaskID, nil)
+		assert.NoError(t, err, "TestCase: %s", k)
+		assert.Equal(t, tc.Result, task.ID, "TestCase: %s", k)
 	}
 }
 

--- a/testing_utils_test.go
+++ b/testing_utils_test.go
@@ -35,9 +35,9 @@ const (
 	fakeMarathonURL   = "http://127.0.0.1:3000,127.0.0.1:3000,127.0.0.1:3000"
 	fakeGroupName     = "/test"
 	fakeGroupName1    = "/qa/product/1"
-	fakeAppName       = "/fake_app"
-	fakeTaskID        = "fake_app.12345"
-	fakeAppNameBroken = "/fake_app_broken"
+	fakeAppName       = "/fake-app"
+	fakeTaskID        = "fake-app.fake-task"
+	fakeAppNameBroken = "/fake-app-broken"
 	fakeDeploymentID  = "867ed450-f6a8-4d33-9b0e-e11c5513990b"
 	fakeAPIFilename   = "./tests/rest-api/methods.yml"
 	fakeAPIPort       = 3000

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -2,7 +2,7 @@
   method: GET
   content: |
     pong
-- uri: /v2/apps/fake_app/versions
+- uri: /v2/apps/fake-app/versions
   method: GET
   content: |
     {
@@ -54,7 +54,7 @@
               "timeoutSeconds": 5
           }
       ],
-      "id": "/fake_app",
+      "id": "/fake-app",
       "instances": 2,
       "mem": 50.0,
       "ports": [
@@ -120,7 +120,7 @@
                     "timeoutSeconds": 20
                 }
             ],
-            "id": "/fake_app",
+            "id": "/fake-app",
             "instances": 2,
             "mem": 64.0,
             "ports": [
@@ -183,7 +183,7 @@
                     "timeoutSeconds": 20
                 }
             ],
-            "id": "/fake_app_broken",
+            "id": "/fake-app-broken",
             "instances": 2,
             "mem": 64.0,
             "ports": [
@@ -203,39 +203,45 @@
         }
     ]
     }
-- uri: /v2/apps/fake_app/restart
+- uri: /v2/apps/fake-app/restart
   method: POST
   content: |
     {
       "deploymentId": "83b215a6-4e26-4e44-9333-5c385eda6438",
       "version": "2014-08-26T07:37:50.462Z"
     }
-- uri: /v2/apps/fake_app
+- uri: /v2/apps/fake-app
   method: DELETE
   content: |
     {
       "deploymentId": "83b215a6-4e26-4e44-9333-5c385eda6438",
       "version": "2014-08-26T07:37:50.462Z"
     }
-- uri: /v2/apps/fake_app/tasks
+- uri: /v2/apps/fake-app/tasks
   method: GET
   content: |
     {
         "tasks": [{"id": "1"},{"id": "2"}]
     }
-- uri: /v2/apps/fake_app/tasks
+- uri: /v2/apps/fake-app/tasks
   method: DELETE
   content: |
     {
         "tasks": []
     }
-- uri: /v2/apps/fake_app/tasks/fake_app.12345
+- uri: /v2/apps/fake-app/tasks/fake-app.fake-task
   method: DELETE
   content: |
     {
-        "task": {"id": "fake_app.12345"}
+        "task": {"id": "fake-app.fake-task"}
     }
-- uri: /v2/apps/fake_app/versions/2014-09-12T23:28:21.737Z
+- uri: /v2/apps/fake-group/fake-app/tasks/fake-group_fake-app.fake-task
+  method: DELETE
+  content: |
+    {
+        "task": {"id": "fake-group_fake-app.fake-task"}
+    }
+- uri: /v2/apps/fake-app/versions/2014-09-12T23:28:21.737Z
   method: GET
   content: |
     {
@@ -278,7 +284,7 @@
                 "timeoutSeconds": 10
             }
         ],
-        "id": "/fake_app",
+        "id": "/fake-app",
         "instances": 2,
         "lastTaskFailure": {
             "appId": "/toggle",
@@ -350,7 +356,7 @@
         "user": null,
         "version": "2014-09-12T23:28:21.737Z"
     }
-- uri: /v2/apps/fake_app
+- uri: /v2/apps/fake-app
   method: GET
   content: |
     {
@@ -394,7 +400,7 @@
                 "timeoutSeconds": 10
             }
         ],
-        "id": "/fake_app",
+        "id": "/fake-app",
         "instances": 2,
         "lastTaskFailure": {
             "appId": "/toggle",
@@ -467,7 +473,7 @@
         "version": "2014-09-12T23:28:21.737Z"
     }
     }
-- uri: /v2/apps/fake_app_broken
+- uri: /v2/apps/fake-app-broken
   method: GET
   content: |
     {
@@ -511,7 +517,7 @@
                 "timeoutSeconds": 10
             }
         ],
-        "id": "/fake_app_broken",
+        "id": "/fake-app-broken",
         "instances": 2,
         "lastTaskFailure": {
             "appId": "/toggle",
@@ -584,7 +590,7 @@
         "version": "2014-09-12T23:28:21.737Z"
     }
     }
-- uri: /v2/apps/fake_app/versions
+- uri: /v2/apps/fake-app/versions
   method: GET
   content: |
     {
@@ -592,14 +598,14 @@
             "2014-04-04T06:25:31.399Z"
         ]
     }
-- uri: /v2/apps/fake_app
+- uri: /v2/apps/fake-app
   method: PUT
   content: |
     {
       "deploymentId": "83b215a6-4e26-4e44-9333-5c385eda6438",
       "version": "2014-08-26T07:37:50.462Z"
     }
-- uri: /v2/apps/fake_app?force=true
+- uri: /v2/apps/fake-app?force=true
   method: PUT
   content: |
     {


### PR DESCRIPTION
This one is intend to solve #111 
It's worth to mention that marathon is checking if AppID is matching the following regexp
`
^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$
`
Basically it means that _ symbol is not allowed, and it is used as a delimiter between group/subgroup ids and AppID  in TaskID. So I've changed all app ids in test fixture from fake_app to fake-app because it was invalid.