### PR TITLE
fixed ping path to make Ping() work

### DIFF
--- a/const.go
+++ b/const.go
@@ -30,7 +30,7 @@ const (
 	marathonAPIQueue        = marathonAPIVersion + "/queue"
 	marathonAPIInfo         = marathonAPIVersion + "/info"
 	marathonAPILeader       = marathonAPIVersion + "/leader"
-	marathonAPIPing         = "/ping"
+	marathonAPIPing         = "ping"
 )
 
 const (


### PR DESCRIPTION
go-marathon tries to make ping request to http://marathon//ping
This commit removes redundant slash