### PR TITLE
Always encode HTTP error response content into API error instances

### DIFF
--- a/client.go
+++ b/client.go
@@ -277,12 +277,7 @@ func (r *marathonClient) apiCall(method, uri string, body, result interface{}) e
 		return nil
 	}
 
-	apiErr, err := NewAPIError(response.StatusCode, respBody)
-	if err != nil {
-		r.debugLog.Printf("apiCall(): failed to parse error response '%s' with status code %d, error: %s", respBody, response.StatusCode, err)
-	}
-
-	return apiErr
+	return NewAPIError(response.StatusCode, respBody)
 }
 
 var oneLogLineRegex = regexp.MustCompile(`(?m)^\s*`)

--- a/error.go
+++ b/error.go
@@ -57,24 +57,27 @@ func (e *APIError) Error() string {
 
 // NewAPIError creates a new APIError instance from the given response code and content.
 func NewAPIError(code int, content []byte) error {
+	var errDef errorDefinition
 	switch {
 	case code == http.StatusBadRequest:
-		return parseContent(&badRequestDef{}, content)
+		errDef = &badRequestDef{}
 	case code == http.StatusUnauthorized:
-		return parseContent(&simpleErrDef{code: ErrCodeUnauthorized}, content)
+		errDef = &simpleErrDef{code: ErrCodeUnauthorized}
 	case code == http.StatusForbidden:
-		return parseContent(&simpleErrDef{code: ErrCodeForbidden}, content)
+		errDef = &simpleErrDef{code: ErrCodeForbidden}
 	case code == http.StatusNotFound:
-		return parseContent(&simpleErrDef{code: ErrCodeNotFound}, content)
+		errDef = &simpleErrDef{code: ErrCodeNotFound}
 	case code == http.StatusConflict:
-		return parseContent(&conflictDef{}, content)
+		errDef = &conflictDef{}
 	case code == 422:
-		return parseContent(&unprocessableEntityDef{}, content)
+		errDef = &unprocessableEntityDef{}
 	case code >= http.StatusInternalServerError:
-		return parseContent(&simpleErrDef{code: ErrCodeServer}, content)
+		errDef = &simpleErrDef{code: ErrCodeServer}
 	default:
-		return parseContent(&simpleErrDef{code: ErrCodeUnknown}, content)
+		errDef = &simpleErrDef{code: ErrCodeUnknown}
 	}
+
+	return parseContent(errDef, content)
 }
 
 type errorDefinition interface {


### PR DESCRIPTION
This commit comprises two major changes:

- Instead of returning nil on non-JSON-parsable content from HTTP error  responses, fall back to encoding the content as-is.
- For unknown errors, try to parse the content as well.

Effectively, we always return a (non-nil) APIError instance and thus can simplify NewAPIError's signature by dropping the second (parse) error return value. We also stop returning nil error values that do not equal to nil, a problem known to [Go](https://golang.org/doc/faq#nil_error). We also take the opportunity to simplify the error-identifying switch statement.

Finally, we convert the existing error parsing tests into table-driven ones to increase readability and be more in-line with the conventional Go testing style.

Fixes #151.
Fixes #152.