### PR TITLE
Fix internal golint errors

### DIFF
--- a/application.go
+++ b/application.go
@@ -562,7 +562,6 @@ func (r *marathonClient) WaitOnApplication(name string, timeout time.Duration) e
 			}
 		}
 	}
-	return nil
 }
 
 func (r *marathonClient) appExistAndRunning(name string) bool {

--- a/health.go
+++ b/health.go
@@ -28,22 +28,25 @@ type HealthCheck struct {
 	TimeoutSeconds         int      `json:"timeoutSeconds,omitempty"`
 }
 
-//
+// SetCommand sets the given command on the health check.
 func (h HealthCheck) SetCommand(c Command) HealthCheck {
 	h.Command = &c
 	return h
 }
 
+// SetPortIndex sets the given port index on the health check.
 func (h HealthCheck) SetPortIndex(i int) HealthCheck {
 	h.PortIndex = &i
 	return h
 }
 
+// SetPath sets the given path on the health check.
 func (h HealthCheck) SetPath(p string) HealthCheck {
 	h.Path = &p
 	return h
 }
 
+// SetMaxConsecutiveFailures sets the maximum consecutive failures on the health check.
 func (h HealthCheck) SetMaxConsecutiveFailures(i int) HealthCheck {
 	h.MaxConsecutiveFailures = &i
 	return h

--- a/task.go
+++ b/task.go
@@ -41,6 +41,7 @@ type Task struct {
 	Version            string               `json:"version"`
 }
 
+// IPAddress represents a task's IP address and protocol.
 type IPAddress struct {
 	IPAddress string `json:"ipAddress"`
 	Protocol  string `json:"protocol"`

--- a/task_test.go
+++ b/task_test.go
@@ -110,6 +110,6 @@ func TestTaskEndpoints(t *testing.T) {
 	assert.Equal(t, endpoints[0], "10.141.141.10:31045", t)
 	assert.Equal(t, endpoints[1], "10.141.141.10:31234", t)
 
-	endpoints, err = endpoint.Client.TaskEndpoints(fakeAppNameBroken, 80, true)
+	_, err = endpoint.Client.TaskEndpoints(fakeAppNameBroken, 80, true)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
This PR fixes all remaining, _internal_ golint errors.

By internal, we mean those that are subject to go-marathon itself and not imposed by a third-party package imported.