### PR TITLE
Move contribution guidelines into separate file and flesh out.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contribution Guidelines
+
+## Pre-Development
+- Look for an existing Github issue describing the bug you have found/feature request you would like to see getting implemented.
+- If no issue exists and there is reason to believe that your (non-trivial) contribution might be subject to an up-front design discussion, file an issue first and propose your idea.
+
+## Development
+- Fork the repository.
+- Create a feature branch (`git checkout -b my-new-feature master`).
+- Commit your changes, preferring one commit per logical unit of work. Often times, this simply means having a single commit.
+- If applicable, update the documentation in the [README file](README.md).
+- In the vast majority of cases, you should add/amend a (regression) test for your bug fix/feature.
+- Push your branch (`git push origin my-new-feature`).
+- Create a new pull request.
+- Address any comments your reviewer raises, pushing additional commits onto your branch along the way. In particular, refrain from amending/force-pushing until you receive an LGTM (Looks Good To Me) from your reviewer. This will allow for a better review experience.

--- a/README.md
+++ b/README.md
@@ -244,9 +244,4 @@ See [events.go](events.go) for a full list of event IDs.
 
 ## Contributing
 
- - Fork it
- - Create your feature branch (git checkout -b my-new-feature)
- - Commit your changes (git commit -am 'Add some feature')
- - Push to the branch (git push origin my-new-feature)
- - Create new Pull Request
- - If applicable, update the README.md
+See the [contribution guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
`CONTRIBUTING.md` will make Github show the file during the creation of a PR.

I also fleshed things out a bit more, adding things I find important for go-marathon specifically and in general.