### PR TITLE
Added IpAddress for applications (Ip Per Task)

### DIFF
--- a/application.go
+++ b/application.go
@@ -34,6 +34,25 @@ type Applications struct {
 	Apps []Application `json:"apps"`
 }
 
+// IpAddress is used by Ip Per Task Funcionality https://mesosphere.github.io/marathon/docs/ip-per-task.html
+type IpAddress struct {
+	Groups []string `json:"groups,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
+	Discovery *Discovery `json:"discovery,omitempty"`
+}
+
+// Discovery provides info about ports expose by Ip Per Task Funcionality
+type Discovery struct {
+	Ports []*Ports `json:"ports,ommitempty"`
+}
+
+// Ports provides info about ports used by Ip Per Task
+type Ports struct {
+	Number int `json:"number,omitempty"`
+	Name string `json:"name:omitempty"`
+	Labels map[string]string
+}
+
 // Application is the definition for an application in marathon
 type Application struct {
 	ID                    string              `json:"id,omitempty"`
@@ -69,6 +88,7 @@ type Application struct {
 	AcceptedResourceRoles []string            `json:"acceptedResourceRoles,omitempty"`
 	LastTaskFailure       *LastTaskFailure    `json:"lastTaskFailure,omitempty"`
 	Fetch                 []Fetch             `json:"fetch"`
+	IpAddress							*IpAddress					`json:"ipAddress,omitempty"`
 }
 
 // ApplicationVersions is a collection of application versions for a specific app in marathon

--- a/application.go
+++ b/application.go
@@ -34,19 +34,19 @@ type Applications struct {
 	Apps []Application `json:"apps"`
 }
 
-// IpAddress is used by Ip Per Task Funcionality https://mesosphere.github.io/marathon/docs/ip-per-task.html
-type IpAddress struct {
+// IPAddressPerTask is used by IP-per-task functionality Funcionality https://mesosphere.github.io/marathon/docs/ip-per-task.html
+type IPAddressPerTask struct {
 	Groups []string `json:"groups,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 	Discovery *Discovery `json:"discovery,omitempty"`
 }
 
-// Discovery provides info about ports expose by Ip Per Task Funcionality
+// Discovery provides info about ports expose by Ip-per-task Funcionality
 type Discovery struct {
 	Ports []*Ports `json:"ports,ommitempty"`
 }
 
-// Ports provides info about ports used by Ip Per Task
+// Ports provides info about ports used by Ip-per-task
 type Ports struct {
 	Number int `json:"number,omitempty"`
 	Name string `json:"name:omitempty"`
@@ -88,7 +88,7 @@ type Application struct {
 	AcceptedResourceRoles []string            `json:"acceptedResourceRoles,omitempty"`
 	LastTaskFailure       *LastTaskFailure    `json:"lastTaskFailure,omitempty"`
 	Fetch                 []Fetch             `json:"fetch"`
-	IpAddress							*IpAddress					`json:"ipAddress,omitempty"`
+	IPAddressPerTask			*IPAddressPerTask		`json:"ipAddress,omitempty"`
 }
 
 // ApplicationVersions is a collection of application versions for a specific app in marathon

--- a/application.go
+++ b/application.go
@@ -34,22 +34,22 @@ type Applications struct {
 	Apps []Application `json:"apps"`
 }
 
-// IPAddressPerTask is used by IP-per-task functionality Funcionality https://mesosphere.github.io/marathon/docs/ip-per-task.html
+// IPAddressPerTask is used by IP-per-task functionality https://mesosphere.github.io/marathon/docs/ip-per-task.html
 type IPAddressPerTask struct {
-	Groups []string `json:"groups,omitempty"`
-	Labels map[string]string `json:"labels,omitempty"`
-	Discovery *Discovery `json:"discovery,omitempty"`
+	Groups    []string          `json:"groups,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	Discovery *Discovery        `json:"discovery,omitempty"`
 }
 
-// Discovery provides info about ports expose by Ip-per-task Funcionality
+// Discovery provides info about ports expose by Ip-per-task functionality
 type Discovery struct {
 	Ports []*Ports `json:"ports,ommitempty"`
 }
 
 // Ports provides info about ports used by Ip-per-task
 type Ports struct {
-	Number int `json:"number,omitempty"`
-	Name string `json:"name:omitempty"`
+	Number int    `json:"number,omitempty"`
+	Name   string `json:"name:omitempty"`
 	Labels map[string]string
 }
 
@@ -88,7 +88,7 @@ type Application struct {
 	AcceptedResourceRoles []string            `json:"acceptedResourceRoles,omitempty"`
 	LastTaskFailure       *LastTaskFailure    `json:"lastTaskFailure,omitempty"`
 	Fetch                 []Fetch             `json:"fetch"`
-	IPAddressPerTask			*IPAddressPerTask		`json:"ipAddress,omitempty"`
+	IPAddressPerTask      *IPAddressPerTask   `json:"ipAddress,omitempty"`
 }
 
 // ApplicationVersions is a collection of application versions for a specific app in marathon


### PR DESCRIPTION
IpAddress is used by Ip Per Task Funcionality https://mesosphere.github.io/marathon/docs/ip-per-task.html