### PR TITLE
Mark app as unhealthy if any health check result is missing.

### DIFF
--- a/application.go
+++ b/application.go
@@ -563,6 +563,12 @@ func (r *marathonClient) ApplicationOK(name string) (bool, error) {
 
 	// step: iterate the application checks and look for false
 	for _, task := range application.Tasks {
+		// Health check results may not be available immediately. Assume
+		// non-healthiness if they are missing for any task.
+		if task.HealthCheckResults == nil {
+			return false, nil
+		}
+
 		for _, check := range task.HealthCheckResults {
 			//When a task is flapping in Marathon, this is sometimes nil
 			if check == nil || !check.Alive {

--- a/application_test.go
+++ b/application_test.go
@@ -388,6 +388,9 @@ func TestApplicationOK(t *testing.T) {
 	ok, err = endpoint.Client.ApplicationOK(fakeAppNameBroken)
 	assert.NoError(t, err)
 	assert.False(t, ok)
+	ok, err = endpoint.Client.ApplicationOK(fakeAppNameUnhealthy)
+	assert.NoError(t, err)
+	assert.False(t, ok)
 }
 
 func verifyApplication(application *Application, t *testing.T) {

--- a/testing_utils_test.go
+++ b/testing_utils_test.go
@@ -32,13 +32,14 @@ import (
 )
 
 const (
-	fakeMarathonURL   = "http://127.0.0.1:3000,127.0.0.1:3000,127.0.0.1:3000"
-	fakeGroupName     = "/test"
-	fakeGroupName1    = "/qa/product/1"
-	fakeAppName       = "/fake-app"
-	fakeTaskID        = "fake-app.fake-task"
-	fakeAppNameBroken = "/fake-app-broken"
-	fakeDeploymentID  = "867ed450-f6a8-4d33-9b0e-e11c5513990b"
+	fakeMarathonURL      = "http://127.0.0.1:3000,127.0.0.1:3000,127.0.0.1:3000"
+	fakeGroupName        = "/test"
+	fakeGroupName1       = "/qa/product/1"
+	fakeAppName          = "/fake-app"
+	fakeTaskID           = "fake-app.fake-task"
+	fakeAppNameBroken    = "/fake-app-broken"
+	fakeDeploymentID     = "867ed450-f6a8-4d33-9b0e-e11c5513990b"
+	fakeAppNameUnhealthy = "/no-health-check-results-app"
 )
 
 var (

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -1246,3 +1246,51 @@
         }
     ]
     }
+- uri: /v2/apps/no-health-check-results-app
+  method: GET
+  content: |
+    {
+    "app": {
+        "healthChecks": [
+            {
+                "command": null,
+                "gracePeriodSeconds": 5,
+                "intervalSeconds": 10,
+                "maxConsecutiveFailures": 3,
+                "path": "/health",
+                "portIndex": 0,
+                "protocol": "HTTP",
+                "timeoutSeconds": 10
+            }
+        ],
+        "id": "/no-health-check-results-app",
+        "instances": 2,
+        "mem": 32.0,
+        "ports": [
+            10000
+        ],
+        "tasks": [
+            {
+                "appId": "/no-health-check-results-app",
+                "healthCheckResults": [
+                    {
+                        "alive": true,
+                        "consecutiveFailures": 0,
+                        "firstSuccess": "2014-09-13T00:20:28.101Z",
+                        "lastFailure": null,
+                        "lastSuccess": "2014-09-13T00:25:07.506Z",
+                        "taskId": "toggle.802df2ae-3ad4-11e4-a400-56847afe9799"
+                    }
+                ],
+                "id": "task1.802df2ae-3ad4-11e4-a400-56847afe9799"
+            },
+            {
+                "appId": "/no-health-check-results-app",
+                "id": "task2.7c99814d-3ad4-11e4-a400-56847afe9799"
+            }
+        ],
+        "tasksRunning": 2,
+        "tasksStaged": 0,
+        "version": "2014-09-12T23:28:21.737Z"
+    }
+    }


### PR DESCRIPTION
During deployments, Marathon does not immediately return health check results. We need to play it safe here and consider such apps as unhealthy.

Fixes #118.