### PR TITLE
Add message as a field in EventStatusUpdate

### DIFF
--- a/events.go
+++ b/events.go
@@ -134,6 +134,7 @@ type EventStatusUpdate struct {
 	SlaveID     string       `json:"slaveId,omitempty"`
 	TaskID      string       `json:"taskId"`
 	TaskStatus  string       `json:"taskStatus"`
+	Message     string       `json:"message,omitempty"`
 	AppID       string       `json:"appId"`
 	Host        string       `json:"host"`
 	Ports       []int        `json:"ports,omitempty"`


### PR DESCRIPTION
According to the Marathon API docs (https://mesosphere.github.io/marathon/docs/generated/api.html#v2_events_get), a message field is included in the status_update_event. We need this message specifically for when a task fails as it gives a failure reason. This change updates the EventStatusUpdate structure to include said message field.