### PR TITLE
Fix timeout error in WaitOnApplication

### DIFF
--- a/application.go
+++ b/application.go
@@ -616,7 +616,7 @@ func (r *marathonClient) WaitOnApplication(name string, timeout time.Duration) e
 	}
 
 	timeoutTimer := time.After(timeout)
-	ticker := time.NewTicker(time.Millisecond * 500)
+	ticker := time.NewTicker(r.waitTime)
 	defer ticker.Stop()
 
 	for {

--- a/application.go
+++ b/application.go
@@ -615,12 +615,13 @@ func (r *marathonClient) WaitOnApplication(name string, timeout time.Duration) e
 		return nil
 	}
 
+	timeoutTimer := time.After(timeout)
 	ticker := time.NewTicker(time.Millisecond * 500)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-time.After(timeout):
+		case <-timeoutTimer:
 			return ErrTimeoutError
 		case <-ticker.C:
 			if r.appExistAndRunning(name) {

--- a/application.go
+++ b/application.go
@@ -616,7 +616,7 @@ func (r *marathonClient) WaitOnApplication(name string, timeout time.Duration) e
 	}
 
 	timeoutTimer := time.After(timeout)
-	ticker := time.NewTicker(r.waitTime)
+	ticker := time.NewTicker(r.pollingWaitTime)
 	defer ticker.Stop()
 
 	for {

--- a/application_test.go
+++ b/application_test.go
@@ -466,9 +466,15 @@ func TestWaitOnApplication(t *testing.T) {
 	err = endpoint.Client.WaitOnApplication(fakeAppName, 1*time.Second)
 	assert.NoError(t, err)
 
-	err = endpoint.Client.WaitOnApplication("no_such_app", 1*time.Millisecond)
+	err = nil
+	go func() {
+		err = endpoint.Client.WaitOnApplication("no_such_app", 1*time.Second)
+	}()
+	timer := time.NewTimer(1200*time.Millisecond)
+	<- timer.C
 	assert.IsType(t, err, ErrTimeoutError)
 }
+
 func TestAppExistAndRunning(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, nil)
 	defer endpoint.Close()

--- a/client.go
+++ b/client.go
@@ -175,6 +175,8 @@ type marathonClient struct {
 	listeners map[EventsChannel]int
 	// a custom logger for debug log messages
 	debugLog *log.Logger
+	// wait time between repetitive requests to API
+	waitTime time.Duration
 }
 
 // NewClient creates a new marathon client
@@ -201,6 +203,7 @@ func NewClient(config Config) (Marathon, error) {
 		cluster:    cluster,
 		httpClient: config.HTTPClient,
 		debugLog:   log.New(debugLogOutput, "", 0),
+		waitTime:   time.Duration(config.WaitTime) * time.Millisecond,
 	}, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -175,8 +175,8 @@ type marathonClient struct {
 	listeners map[EventsChannel]int
 	// a custom logger for debug log messages
 	debugLog *log.Logger
-	// wait time between repetitive requests to API
-	waitTime time.Duration
+	// wait time between repetitive requests to the API during polling
+	pollingWaitTime time.Duration
 }
 
 // NewClient creates a new marathon client
@@ -198,12 +198,12 @@ func NewClient(config Config) (Marathon, error) {
 	}
 
 	return &marathonClient{
-		config:     config,
-		listeners:  make(map[EventsChannel]int, 0),
-		cluster:    cluster,
-		httpClient: config.HTTPClient,
-		debugLog:   log.New(debugLogOutput, "", 0),
-		waitTime:   time.Duration(config.WaitTime) * time.Millisecond,
+		config:          config,
+		listeners:       make(map[EventsChannel]int, 0),
+		cluster:         cluster,
+		httpClient:      config.HTTPClient,
+		debugLog:        log.New(debugLogOutput, "", 0),
+		pollingWaitTime: time.Duration(config.PollingWaitTime) * time.Millisecond,
 	}, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -47,8 +47,8 @@ type Config struct {
 	LogOutput io.Writer
 	// HTTPClient is the http client
 	HTTPClient *http.Client
-	// WaitTime time in milliseconds
-	WaitTime int
+	// wait time (in milliseconds) between repetitive requests to the API during polling
+	PollingWaitTime int
 }
 
 // NewDefaultConfig create a default client config
@@ -59,6 +59,6 @@ func NewDefaultConfig() Config {
 		EventsPort:      10001,
 		EventsInterface: "eth0",
 		LogOutput:       ioutil.Discard,
-		WaitTime:        500,
+		PollingWaitTime: 500,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -47,6 +47,8 @@ type Config struct {
 	LogOutput io.Writer
 	// HTTPClient is the http client
 	HTTPClient *http.Client
+	// WaitTime time in milliseconds
+	WaitTime int
 }
 
 // NewDefaultConfig create a default client config
@@ -57,5 +59,6 @@ func NewDefaultConfig() Config {
 		EventsPort:      10001,
 		EventsInterface: "eth0",
 		LogOutput:       ioutil.Discard,
+		WaitTime:        500,
 	}
 }

--- a/deployment.go
+++ b/deployment.go
@@ -151,6 +151,6 @@ func (r *marathonClient) WaitOnDeployment(id string, timeout time.Duration) erro
 		if !found {
 			return nil
 		}
-		time.Sleep(r.waitTime)
+		time.Sleep(r.pollingWaitTime)
 	}
 }

--- a/deployment.go
+++ b/deployment.go
@@ -151,6 +151,6 @@ func (r *marathonClient) WaitOnDeployment(id string, timeout time.Duration) erro
 		if !found {
 			return nil
 		}
-		time.Sleep(time.Duration(2) * time.Second)
+		time.Sleep(r.waitTime)
 	}
 }

--- a/group.go
+++ b/group.go
@@ -195,7 +195,7 @@ func (r *marathonClient) WaitOnGroup(name string, timeout time.Duration) error {
 					return nil
 				}
 			}
-			time.Sleep(time.Duration(1) * time.Second)
+			time.Sleep(r.pollingWaitTime)
 		}
 		return nil
 	})


### PR DESCRIPTION
timer.After is a function who returns a new channel, this causes a problem because the timer is resetting in each iteration.

You can see a detailed explain in http://stackoverflow.com/questions/35036653/why-doesnt-this-golang-code-to-select-among-multiple-time-after-channels-work/35036775

Regards