### PR TITLE
Drop question mark on empty query params in Applications().

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@
 language: go
 go:
   - 1.5
+  - 1.6
+  - 1.7
 install:
   - make test examples

--- a/application.go
+++ b/application.go
@@ -434,8 +434,13 @@ func (r *Application) String() string {
 
 // Applications retrieves an array of all the applications which are running in marathon
 func (r *marathonClient) Applications(v url.Values) (*Applications, error) {
+	query := v.Encode()
+	if query != "" {
+		query = "?" + query
+	}
+
 	applications := new(Applications)
-	err := r.apiGet(marathonAPIApps+"?"+v.Encode(), nil, applications)
+	err := r.apiGet(marathonAPIApps+query, nil, applications)
 	if err != nil {
 		return nil, err
 	}

--- a/application_test.go
+++ b/application_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package marathon
 
 import (
+	"net/url"
 	"testing"
 	"time"
 
@@ -265,6 +266,13 @@ func TestApplications(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, applications)
 	assert.Equal(t, len(applications.Apps), 2)
+
+	v := url.Values{}
+	v.Set("cmd", "nginx")
+	applications, err = endpoint.Client.Applications(v)
+	assert.NoError(t, err)
+	assert.NotNil(t, applications)
+	assert.Equal(t, len(applications.Apps), 1)
 }
 
 func TestListApplications(t *testing.T) {

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -203,6 +203,17 @@
         }
     ]
     }
+- uri: /v2/apps?cmd=nginx
+  method: GET
+  content: |
+    {
+    "apps": [
+        {
+            "args": null,
+            "cmd": "nginx"
+        }
+    ]
+    }
 - uri: /v2/apps/fake-app/restart
   method: POST
   content: |


### PR DESCRIPTION
Behavior of `url.Parse()` changed in Go 1.7.

Fixes #194.