### PR TITLE
Signal goroutine termination on event listener removal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - [#201][PR201]: Subscribe method is now exposed on the client to allow subscription of callback URL's
 
+### Fixed
+- [#205][PR205]: Fix memory leak by signalling goroutine termination on event listener removal.
+
+### Changed
+- [#205][PR205]: Change AddEventsListener to return event channel instead of taking one.
+
 ## [0.2.0] - 2016-09-23
+### Added
 - [#196][PR196]: Port definitions.
 - [#191][PR191]: name and labels to portMappings.
 
@@ -64,6 +71,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [0.1.1]: https://github.com/gambol99/go-marathon/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/gambol99/go-marathon/compare/v0.0.1...v0.1.0
 
+[PR205]: https://github.com/gambol99/go-marathon/pull/205
 [PR202]: https://github.com/gambol99/go-marathon/pull/202
 [PR201]: https://github.com/gambol99/go-marathon/pull/201
 [PR196]: https://github.com/gambol99/go-marathon/pull/196

--- a/README.md
+++ b/README.md
@@ -166,8 +166,7 @@ if err != nil {
 }
 
 // Register for events
-events := make(marathon.EventsChannel, 5)
-err = client.AddEventsListener(events, marathon.EventIDApplications)
+events, err = client.AddEventsListener(marathon.EventIDApplications)
 if err != nil {
 	log.Fatalf("Failed to register for events, %s", err)
 }
@@ -215,8 +214,7 @@ if err != nil {
 }
 
 // Register for events
-events := make(marathon.EventsChannel, 5)
-err = client.AddEventsListener(events, marathon.EventIDApplications)
+events, err = client.AddEventsListener(marathon.EventIDApplications)
 if err != nil {
 	log.Fatalf("Failed to register for events, %s", err)
 }

--- a/client.go
+++ b/client.go
@@ -120,7 +120,7 @@ type Marathon interface {
 	// a list of current subscriptions
 	Subscriptions() (*Subscriptions, error)
 	// add a events listener
-	AddEventsListener(channel EventsChannel, filter int) error
+	AddEventsListener(filter int) (EventsChannel, error)
 	// remove a events listener
 	RemoveEventsListener(channel EventsChannel)
 	// Subscribe a callback URL
@@ -159,6 +159,12 @@ var (
 	ErrTimeoutError = errors.New("the operation has timed out")
 )
 
+// EventsChannelContext holds contextual data for an EventsChannel.
+type EventsChannelContext struct {
+	filter int
+	done   chan struct{}
+}
+
 type marathonClient struct {
 	sync.RWMutex
 	// the configuration for the client
@@ -174,7 +180,7 @@ type marathonClient struct {
 	// the marathon cluster
 	cluster Cluster
 	// a map of service you wish to listen to
-	listeners map[EventsChannel]int
+	listeners map[EventsChannel]EventsChannelContext
 	// a custom logger for debug log messages
 	debugLog *log.Logger
 	// wait time between repetitive requests to the API during polling
@@ -201,7 +207,7 @@ func NewClient(config Config) (Marathon, error) {
 
 	return &marathonClient{
 		config:          config,
-		listeners:       make(map[EventsChannel]int, 0),
+		listeners:       make(map[EventsChannel]EventsChannelContext),
 		cluster:         cluster,
 		httpClient:      config.HTTPClient,
 		debugLog:        log.New(debugLogOutput, "", 0),

--- a/examples/events_callback_transport/main.go
+++ b/examples/events_callback_transport/main.go
@@ -54,10 +54,10 @@ func main() {
 	assert(err)
 
 	// Register for events
-	events := make(marathon.EventsChannel, 5)
-	deployments := make(marathon.EventsChannel, 5)
-	assert(client.AddEventsListener(events, marathon.EventIDApplications))
-	assert(client.AddEventsListener(deployments, marathon.EventIDDeploymentStepSuccess))
+	events, err := client.AddEventsListener(marathon.EventIDApplications)
+	assert(err)
+	deployments, err := client.AddEventsListener(marathon.EventIDDeploymentStepSuccess)
+	assert(err)
 
 	// Listen for x seconds and then split
 	timer := time.After(time.Duration(timeout) * time.Second)

--- a/examples/events_sse_transport/main.go
+++ b/examples/events_sse_transport/main.go
@@ -49,10 +49,10 @@ func main() {
 	assert(err)
 
 	// Register for events
-	events := make(marathon.EventsChannel, 5)
-	deployments := make(marathon.EventsChannel, 5)
-	assert(client.AddEventsListener(events, marathon.EventIDApplications))
-	assert(client.AddEventsListener(deployments, marathon.EventIDDeploymentStepSuccess))
+	events, err := client.AddEventsListener(marathon.EventIDApplications)
+	assert(err)
+	deployments, err := client.AddEventsListener(marathon.EventIDDeploymentStepSuccess)
+	assert(err)
 
 	// Listen for x seconds and then split
 	timer := time.After(time.Duration(timeout) * time.Second)


### PR DESCRIPTION
Fixes goroutine/memory leakage where an event consumer would stop receiving events from the channel while pending goroutines were still trying to deliver some.

The chosen approach only makes sense with unbuffered channels due to the `select` involved; as such, we change `AddEventListener`'s signature to return a channel to the consumer instead of expecting one. Passing buffered channels to `AddEventListener` was never overly useful in the
first place, however, as we use goroutines to avoid blocking on slow receivers, implictly doing event buffering this way already.

Changes in detail:

- Modify `AddEventListener`'s signature.
- Change listener's value type to struct holding both filters and a per-listener done channel.
- Close done channel on `RemoveEventListener`, and select between outbound and done channel in event-processing goroutine.
- Extend tests.
- Make existing tests more robust.
- Update examples.
- Update README file.

Fixes #198.