### PR TITLE
Close event channel on event listener removal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [#211][PR211] Close event channel on event listener removal.
 
 ## [0.3.0] - 2016-09-28
 - [#201][PR201]: Subscribe method is now exposed on the client to allow subscription of callback URL's
@@ -74,6 +76,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [0.1.1]: https://github.com/gambol99/go-marathon/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/gambol99/go-marathon/compare/v0.0.1...v0.1.0
 
+[PR211]: https://github.com/gambol99/go-marathon/pull/211
 [PR205]: https://github.com/gambol99/go-marathon/pull/205
 [PR202]: https://github.com/gambol99/go-marathon/pull/202
 [PR201]: https://github.com/gambol99/go-marathon/pull/201

--- a/client.go
+++ b/client.go
@@ -161,8 +161,9 @@ var (
 
 // EventsChannelContext holds contextual data for an EventsChannel.
 type EventsChannelContext struct {
-	filter int
-	done   chan struct{}
+	filter     int
+	done       chan struct{}
+	completion *sync.WaitGroup
 }
 
 type marathonClient struct {


### PR DESCRIPTION
On invocation of `RemoveEventsListener`, wait for all pending goroutines to complete and close the events channel afterwards. This will enable clients for-looping through the event channel to terminate naturally.

Also merge two tests into one covering all relevant cases.

This PR picks up a left out TODO identified along #198.