### PR TITLE
Fix unmarshalling of DeploymentPlan for Marathon v1.X API

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -60,47 +60,7 @@ type DeploymentPlan struct {
 	Version  	string            	`json:"version"`
 	Original 	*Group            	`json:"original"`
 	Target   	*Group            	`json:"target"`
-	Steps    	[]*DeploymentStep 	`json:"-"`
-	XXStepsRaw	json.RawMessage		`json:"steps"` // Holds raw steps JSON to unmarshal later
-}
-
-// Allows loading of deployment steps from the Marathon v1.X API
-func (d *DeploymentPlan) UnmarshalJSON(b []byte) error {
-	dp := &struct {
-		ID       	string            	`json:"id"`
-		Version  	string            	`json:"version"`
-		Original 	*Group            	`json:"original"`
-		Target   	*Group            	`json:"target"`
-		XXStepsRaw  json.RawMessage 	`json:"steps"`
-	}{}
-	err := json.Unmarshal(b, &dp)
-	if err != nil {
-		return err
-	}
-	d.ID = dp.ID
-	d.Version = dp.Version
-	d.Original = dp.Original
-	d.Target = dp.Target
-	var deploymentStepArray []*DeploymentStep
-	if len(dp.XXStepsRaw) != 0 {
-		err = json.Unmarshal(dp.XXStepsRaw, &deploymentStepArray)
-		if err != nil {
-			return err
-		}
-		d.Steps = deploymentStepArray
-	}
-	if len(d.Steps)>0 && d.Steps[0].Action == "" {
-		var stepActionsArray []*StepActions
-		err = json.Unmarshal(dp.XXStepsRaw, &stepActionsArray)
-		if err != nil {
-			return err
-		}
-		for stepIndex, step := range stepActionsArray {
-			d.Steps[stepIndex].Action = step.Actions[0].Type
-			d.Steps[stepIndex].App = step.Actions[0].App
-		}
-	}
-	return nil
+	Steps    	[]*StepActions 		`json:"steps"`
 }
 
 // Deployments retrieves a list of current deployments

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -133,7 +133,18 @@ var testCases = testCaseList{
 		source: `{
 	"eventType": "deployment_info",
 	"timestamp": "2016-07-29T08:03:52.542Z",
-	"plan": {},
+	"plan": {
+		"id": "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+		"version": "2016-07-29T08:03:52.542Z",
+		"original": {},
+		"target": {},
+		"steps": [
+			{
+				"action": "ScaleApplication",
+				"app": "/my-app"
+			}
+		]
+	},
 	"currentStep": {
 		"actions": [
 			{
@@ -146,7 +157,77 @@ var testCases = testCaseList{
 		expectation: &EventDeploymentInfo{
 			EventType: "deployment_info",
 			Timestamp: "2016-07-29T08:03:52.542Z",
-			Plan:      &DeploymentPlan{},
+			Plan:      &DeploymentPlan{
+				ID: "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+				Version: "2016-07-29T08:03:52.542Z",
+				Original: &Group{},
+				Target: &Group{},
+				Steps: []*DeploymentStep {
+					{
+						Action: "ScaleApplication",
+						App: "/my-app",
+					},
+				},
+			},
+			CurrentStep: &StepActions{
+				Actions: []struct {
+					Type string `json:"type"`
+					App  string `json:"app"`
+				}{
+					{
+						Type: "ScaleApplication",
+						App:  "/my-app",
+					},
+				},
+			},
+		},
+	},
+	// For marathon 1.X
+	testCase{
+		name: "deployment_step_success",
+		source: `{
+	"eventType": "deployment_step_success",
+	"timestamp": "2016-09-29T03:15:40.176Z",
+	"plan": {
+		"id": "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+		"version": "2016-09-29T03:15:40.176Z",
+		"original": {},
+		"target": {},
+		"steps": [
+			{
+				"actions": [
+					{
+						"type": "ScaleApplication",
+						"app": "/my-app"
+					}
+				]
+			}
+		]
+	},
+	"currentStep": {
+		"actions": [
+			{
+				"type": "ScaleApplication",
+				"app": "/my-app"
+			}
+		]
+	}
+}`,
+		expectation: &EventDeploymentStepSuccess{
+			EventType: "deployment_step_success",
+			Timestamp: "2016-09-29T03:15:40.176Z",
+			Plan:      &DeploymentPlan{
+				ID: "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+				Version: "2016-09-29T03:15:40.176Z",
+				Original: &Group{},
+				Target: &Group{},
+				Steps: []*DeploymentStep {
+					{
+						Action: "ScaleApplication",
+						App: "/my-app",
+					},
+				},
+			},
 			CurrentStep: &StepActions{
 				Actions: []struct {
 					Type string `json:"type"`
@@ -220,7 +301,7 @@ func TestEventStreamEventsReceived(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, &config)
 	defer endpoint.Close()
 
-	events, err := endpoint.Client.AddEventsListener(EventIDApplications | EventIDDeploymentInfo)
+	events, err := endpoint.Client.AddEventsListener(EventIDApplications | EventIDDeploymentInfo | EventIDDeploymentStepSuccess)
 	assert.NoError(t, err)
 
 	almostAllTestCases := testCases[:len(testCases)-1]

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -140,8 +140,12 @@ var testCases = testCaseList{
 		"target": {},
 		"steps": [
 			{
-				"action": "ScaleApplication",
-				"app": "/my-app"
+				"actions": [
+					{
+						"type": "ScaleApplication",
+						"app": "/my-app"
+					}
+				]
 			}
 		]
 	},
@@ -162,69 +166,17 @@ var testCases = testCaseList{
 				Version: "2016-07-29T08:03:52.542Z",
 				Original: &Group{},
 				Target: &Group{},
-				Steps: []*DeploymentStep {
-					{
-						Action: "ScaleApplication",
-						App: "/my-app",
-					},
-				},
-			},
-			CurrentStep: &StepActions{
-				Actions: []struct {
-					Type string `json:"type"`
-					App  string `json:"app"`
-				}{
-					{
-						Type: "ScaleApplication",
-						App:  "/my-app",
-					},
-				},
-			},
-		},
-	},
-	// For marathon 1.X
-	testCase{
-		name: "deployment_step_success",
-		source: `{
-	"eventType": "deployment_step_success",
-	"timestamp": "2016-09-29T03:15:40.176Z",
-	"plan": {
-		"id": "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
-		"version": "2016-09-29T03:15:40.176Z",
-		"original": {},
-		"target": {},
-		"steps": [
-			{
-				"actions": [
-					{
-						"type": "ScaleApplication",
-						"app": "/my-app"
-					}
-				]
-			}
-		]
-	},
-	"currentStep": {
-		"actions": [
-			{
-				"type": "ScaleApplication",
-				"app": "/my-app"
-			}
-		]
-	}
-}`,
-		expectation: &EventDeploymentStepSuccess{
-			EventType: "deployment_step_success",
-			Timestamp: "2016-09-29T03:15:40.176Z",
-			Plan:      &DeploymentPlan{
-				ID: "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
-				Version: "2016-09-29T03:15:40.176Z",
-				Original: &Group{},
-				Target: &Group{},
-				Steps: []*DeploymentStep {
-					{
-						Action: "ScaleApplication",
-						App: "/my-app",
+				Steps: []*StepActions{
+					&StepActions{
+						Actions: []struct {
+							Type string `json:"type"`
+							App  string `json:"app"`
+						}{
+							{
+								Type: "ScaleApplication",
+								App:  "/my-app",
+							},
+						},
 					},
 				},
 			},
@@ -301,7 +253,7 @@ func TestEventStreamEventsReceived(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, &config)
 	defer endpoint.Close()
 
-	events, err := endpoint.Client.AddEventsListener(EventIDApplications | EventIDDeploymentInfo | EventIDDeploymentStepSuccess)
+	events, err := endpoint.Client.AddEventsListener(EventIDApplications | EventIDDeploymentInfo)
 	assert.NoError(t, err)
 
 	almostAllTestCases := testCases[:len(testCases)-1]


### PR DESCRIPTION
In [marathon docs](https://github.com/mesosphere/marathon/blob/master/docs/docs/event-bus.md), a deployment plan message is:
```
{
  ...
  "plan": {
    ...
    "steps": [
      {
        "action": "ScaleApplication",
        "app": "/my-app"
      }
    ],
    "version": "2014-03-01T23:24:14.846Z"
  },
  "currentStep": {
    "actions": [
      {
        "type": "ScaleApplication",
        "app": "/my-app"
      }
    ]
  }
}
```

But in my marathon v1.1.1 environment, the deployment plan message has got the following structure:
```
{
  ...
  "plan": {
    ...
    "steps": [
      {
        "actions": [
          {
            "type": "ScaleApplication",
            "app": "/my-app"
          }
        ]
      }
    ],
    "version": "2016-09-23T03:22:17.119Z"
  },
  "currentStep": {
    "actions": [
      {
        "type": "ScaleApplication",
        "app": "/my-app"
      }
    ]
  },
}
```

Actually, change `Steps    []*DeploymentStep` to `Steps    []*StepActions` in `DeploymentPlan` could solve the problem nice and easy, but for compatibility, I have to use this less-elegant way. 

Thanks.