### PR TITLE
Add external volume definition to container

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -46,9 +46,17 @@ type Parameters struct {
 
 // Volume is the docker volume details associated to the container
 type Volume struct {
-	ContainerPath string `json:"containerPath,omitempty"`
-	HostPath      string `json:"hostPath,omitempty"`
-	Mode          string `json:"mode,omitempty"`
+	ContainerPath string          `json:"containerPath,omitempty"`
+	HostPath      string          `json:"hostPath,omitempty"`
+	External      *ExternalVolume `json:"external,omitempty"`
+	Mode          string          `json:"mode,omitempty"`
+}
+
+// An external volume definition
+type ExternalVolume struct {
+	Name     string             `json:"name,omitempty"`
+	Provider string             `json:"provider,omitempty"`
+	Options  *map[string]string `json:"options,omitempty"`
 }
 
 // Docker is the docker definition from a marathon application
@@ -88,6 +96,37 @@ func (container *Container) Volume(hostPath, containerPath, mode string) *Contai
 func (container *Container) EmptyVolumes() *Container {
 	container.Volumes = &[]Volume{}
 	return container
+}
+
+// Define external elements for a volume
+//      name: the name of the volume
+//      provider: the provider of the volume (e.g. dvdi)
+func (v *Volume) ExternalVolume(name, provider string) *ExternalVolume {
+	ev := ExternalVolume{
+		Name:     name,
+		Provider: provider,
+	}
+	v.External = &ev
+	return &ev
+}
+
+// AddOption adds an option to an ExternalVolume
+//		name:  the name of the option
+//		value: value for the option
+func (ev *ExternalVolume) AddOption(name, value string) *ExternalVolume {
+	if ev.Options == nil {
+		ev.EmptyOptions()
+	}
+	(*ev.Options)[name] = value
+
+	return ev
+}
+
+// EmptyOptions explicitly empties the options
+func (ev *ExternalVolume) EmptyOptions() *ExternalVolume {
+	ev.Options = &map[string]string{}
+
+	return ev
 }
 
 // NewDockerContainer creates a default docker container for you

--- a/docker.go
+++ b/docker.go
@@ -102,12 +102,17 @@ func (container *Container) EmptyVolumes() *Container {
 //      name: the name of the volume
 //      provider: the provider of the volume (e.g. dvdi)
 func (v *Volume) ExternalVolume(name, provider string) *ExternalVolume {
-	ev := ExternalVolume{
+	ev := &ExternalVolume{
 		Name:     name,
 		Provider: provider,
 	}
-	v.External = &ev
-	return &ev
+	v.External = ev
+	return ev
+}
+
+func (v *Volume) EmptyVolume() *Volume {
+	v.External = &ExternalVolume{}
+	return v
 }
 
 // AddOption adds an option to an ExternalVolume

--- a/docker.go
+++ b/docker.go
@@ -101,7 +101,7 @@ func (container *Container) EmptyVolumes() *Container {
 // Define external elements for a volume
 //      name: the name of the volume
 //      provider: the provider of the volume (e.g. dvdi)
-func (v *Volume) ExternalVolume(name, provider string) *ExternalVolume {
+func (v *Volume) SetExternalVolume(name, provider string) *ExternalVolume {
 	ev := &ExternalVolume{
 		Name:     name,
 		Provider: provider,
@@ -110,7 +110,8 @@ func (v *Volume) ExternalVolume(name, provider string) *ExternalVolume {
 	return ev
 }
 
-func (v *Volume) EmptyVolume() *Volume {
+// Empty the external volume definition
+func (v *Volume) EmptyExternalVolume() *Volume {
 	v.External = &ExternalVolume{}
 	return v
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -103,7 +103,7 @@ func TestExternalVolume(t *testing.T) {
 	container := NewDockerApplication().Container
 
 	container.Volume("", "cp", "RW")
-	ev := (*container.Volumes)[0].ExternalVolume("myVolume", "dvdi")
+	ev := (*container.Volumes)[0].SetExternalVolume("myVolume", "dvdi")
 
 	ev.AddOption("prop", "pval")
 	ev.AddOption("dvdi", "rexray")
@@ -117,7 +117,7 @@ func TestExternalVolume(t *testing.T) {
 	}
 
 	// empty the external volume again
-	(*container.Volumes)[0].EmptyVolume()
+	(*container.Volumes)[0].EmptyExternalVolume()
 	ev2 := (*container.Volumes)[0].External
 	assert.Equal(t, ev2.Name, "")
 	assert.Equal(t, ev2.Provider, "")

--- a/docker_test.go
+++ b/docker_test.go
@@ -84,7 +84,22 @@ func TestPortMappingLabels(t *testing.T) {
 	assert.Equal(t, 0, len(*pm.Labels))
 }
 
-func TestExternalVolumes(t *testing.T) {
+func TestVolume(t *testing.T) {
+	container := NewDockerApplication().Container
+
+	container.Volume("hp1", "cp1", "RW")
+	container.Volume("hp2", "cp2", "R")
+
+	assert.Equal(t, 2, len(*container.Volumes))
+	assert.Equal(t, (*container.Volumes)[0].HostPath, "hp1")
+	assert.Equal(t, (*container.Volumes)[0].ContainerPath, "cp1")
+	assert.Equal(t, (*container.Volumes)[0].Mode, "RW")
+	assert.Equal(t, (*container.Volumes)[1].HostPath, "hp2")
+	assert.Equal(t, (*container.Volumes)[1].ContainerPath, "cp2")
+	assert.Equal(t, (*container.Volumes)[1].Mode, "R")
+}
+
+func TestExternalVolume(t *testing.T) {
 	container := NewDockerApplication().Container
 
 	container.Volume("", "cp", "RW")
@@ -93,13 +108,17 @@ func TestExternalVolumes(t *testing.T) {
 	ev.AddOption("prop", "pval")
 	ev.AddOption("dvdi", "rexray")
 
-	assert.Equal(t, (*container.Volumes)[0].ContainerPath, "cp")
-	assert.Equal(t, (*container.Volumes)[0].External.Name, "myVolume")
-	assert.Equal(t, (*container.Volumes)[0].External.Provider, "dvdi")
-	assert.Equal(t, 1, len(*container.Volumes))
+	ev1 := (*container.Volumes)[0].External
+	assert.Equal(t, ev1.Name, "myVolume")
+	assert.Equal(t, ev1.Provider, "dvdi")
+	if assert.Equal(t, len(*ev1.Options), 2) {
+		assert.Equal(t, (*ev1.Options)["dvdi"], "rexray")
+		assert.Equal(t, (*ev1.Options)["prop"], "pval")
+	}
 
-	evt := (*container.Volumes)[0].External
-	assert.Equal(t, (*evt.Options)["dvdi"], "rexray")
-	assert.Equal(t, (*evt.Options)["prop"], "pval")
-	assert.Equal(t, 2, len(*evt.Options))
+	// empty the external volume again
+	(*container.Volumes)[0].EmptyVolume()
+	ev2 := (*container.Volumes)[0].External
+	assert.Equal(t, ev2.Name, "")
+	assert.Equal(t, ev2.Provider, "")
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -83,3 +83,23 @@ func TestPortMappingLabels(t *testing.T) {
 	assert.NotNil(t, pm.Labels)
 	assert.Equal(t, 0, len(*pm.Labels))
 }
+
+func TestExternalVolumes(t *testing.T) {
+	container := NewDockerApplication().Container
+
+	container.Volume("", "cp", "RW")
+	ev := (*container.Volumes)[0].ExternalVolume("myVolume", "dvdi")
+
+	ev.AddOption("prop", "pval")
+	ev.AddOption("dvdi", "rexray")
+
+	assert.Equal(t, (*container.Volumes)[0].ContainerPath, "cp")
+	assert.Equal(t, (*container.Volumes)[0].External.Name, "myVolume")
+	assert.Equal(t, (*container.Volumes)[0].External.Provider, "dvdi")
+	assert.Equal(t, 1, len(*container.Volumes))
+
+	evt := (*container.Volumes)[0].External
+	assert.Equal(t, (*evt.Options)["dvdi"], "rexray")
+	assert.Equal(t, (*evt.Options)["prop"], "pval")
+	assert.Equal(t, 2, len(*evt.Options))
+}


### PR DESCRIPTION
External volumes allow integration with persistent volumes such as NFS or EBS volumes that can be attached to the nodes running the containers. This allows the persistent data to outlive the container in case of a crash and makes it possible to migrate it to wherever the container is moving to.

This pull request replaces #220 