### PR TITLE
Add LastFailureCause field to HealthCheckResult

### DIFF
--- a/health.go
+++ b/health.go
@@ -82,6 +82,7 @@ type HealthCheckResult struct {
 	ConsecutiveFailures int    `json:"consecutiveFailures"`
 	FirstSuccess        string `json:"firstSuccess"`
 	LastFailure         string `json:"lastFailure"`
+	LastFailureCause    string `json:"lastFailureCause"`
 	LastSuccess         string `json:"lastSuccess"`
 	TaskID              string `json:"taskId"`
 }


### PR DESCRIPTION
*Problem:* Marathon health check results include a `LastFailureCause` field that describes the reason for the last health check failure, but the `HealthCheckResult` struct doesn't include a field for it.

I can't find this field explicitly documented in the Marathon API docs, but it's certainly [part of a health check result](https://github.com/mesosphere/marathon/blob/31426bd1f7b091b78748ea7fd83c497db3dfea9e/src/main/scala/mesosphere/marathon/core/health/Health.scala#L11), and in the JSON returned from the tasks endpoints. 

<img width="411" alt="screen shot 2016-11-03 at 10 52 33 am" src="https://cloud.githubusercontent.com/assets/406639/19978538/88dc203c-a1b4-11e6-90a9-b63f0b71df65.png">

Would love to have this exposed. Thanks!
