### PR TITLE
Fix scheme-less endpoint with port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- [#239][PR239] Fix scheme-less endpoint with port.
 
 ## [0.5.0] - 2016-11-07
 ### Fixed
@@ -91,6 +92,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [0.1.1]: https://github.com/gambol99/go-marathon/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/gambol99/go-marathon/compare/v0.0.1...v0.1.0
 
+[PR239]: https://github.com/gambol99/go-marathon/pull/239
 [PR231]: https://github.com/gambol99/go-marathon/pull/231
 [PR229]: https://github.com/gambol99/go-marathon/pull/229
 [PR223]: https://github.com/gambol99/go-marathon/pull/223

--- a/cluster.go
+++ b/cluster.go
@@ -74,13 +74,16 @@ func newCluster(client *http.Client, marathonURL string) (*cluster, error) {
 			defaultProto = u.Scheme
 		}
 		// step: does the url have a protocol schema? if not, use the default
-		if u.Scheme == "" {
-			u, _ = url.Parse(fmt.Sprintf("%s://%s", defaultProto, u.String()))
+		if u.Scheme == "" || u.Opaque != "" {
+			urlWithScheme := fmt.Sprintf("%s://%s", defaultProto, u.String())
+			if u, err = url.Parse(urlWithScheme); err != nil {
+				panic(fmt.Sprintf("unexpected parsing error for URL '%s' with added default scheme: %s", urlWithScheme, err))
+			}
 		}
 
 		// step: check for empty hosts
-		if u.Host == "" || u.Scheme == "" {
-			return nil, newInvalidEndpointError("endpoint: %s must have a schema and host", endpoint)
+		if u.Host == "" {
+			return nil, newInvalidEndpointError("endpoint: %s must have a host", endpoint)
 		}
 
 		// step: create a new node for this endpoint

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -95,8 +95,16 @@ func TestValidClusterHosts(t *testing.T) {
 			Expect: []string{"http://127.0.0.1:8080", "http://127.0.0.2"},
 		},
 		{
+			URL:    "http://127.0.0.1:8080,127.0.0.2:8080",
+			Expect: []string{"http://127.0.0.1:8080", "http://127.0.0.2:8080"},
+		},
+		{
 			URL:    "http://127.0.0.1:8080,https://127.0.0.2",
 			Expect: []string{"http://127.0.0.1:8080", "https://127.0.0.2"},
+		},
+		{
+			URL:    "http://127.0.0.1:8080,https://127.0.0.2:8080",
+			Expect: []string{"http://127.0.0.1:8080", "https://127.0.0.2:8080"},
 		},
 		{
 			URL:    "http://127.0.0.1:8080/path1,127.0.0.2/path2",


### PR DESCRIPTION
A Marathon URL like `http://host1,host2:8080` would not be accepted because `host:8080` is considered as an opaque URL by url.Parse with the scheme being `host` and the opaque part being `8080`. We fix this by prepending the default scheme if URL.Opaque is non-empty.

Other drive-by changes:

- Panic on a parse error when we add the default scheme. (This should   not happen, hence the panic to indicate an invariant.)
- Remove a check for empty scheme. (We should have ruled out this possibility.)

Fixes #238.