### PR TITLE
Pointerize IPAddressPerTask.Discovery.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [#242][PR242] Pointerize IPAddressPerTask.Discovery.
 
 ## [0.5.1] - 2016-11-09
 ### Fixed
@@ -96,6 +98,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [0.1.1]: https://github.com/gambol99/go-marathon/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/gambol99/go-marathon/compare/v0.0.1...v0.1.0
 
+[PR242]: https://github.com/gambol99/go-marathon/pull/242
 [PR239]: https://github.com/gambol99/go-marathon/pull/239
 [PR231]: https://github.com/gambol99/go-marathon/pull/231
 [PR229]: https://github.com/gambol99/go-marathon/pull/229

--- a/application.go
+++ b/application.go
@@ -38,7 +38,7 @@ type Applications struct {
 type IPAddressPerTask struct {
 	Groups      *[]string          `json:"groups,omitempty"`
 	Labels      *map[string]string `json:"labels,omitempty"`
-	Discovery   Discovery          `json:"discovery,omitempty"`
+	Discovery   *Discovery         `json:"discovery,omitempty"`
 	NetworkName string             `json:"networkName,omitempty"`
 }
 
@@ -807,7 +807,7 @@ func (i *IPAddressPerTask) AddGroup(group string) *IPAddressPerTask {
 // SetDiscovery define the discovery to an IPAddressPerTask
 //  discovery: The discovery struct
 func (i *IPAddressPerTask) SetDiscovery(discovery Discovery) *IPAddressPerTask {
-	i.Discovery = discovery
+	i.Discovery = &discovery
 	return i
 }
 

--- a/application_test.go
+++ b/application_test.go
@@ -583,13 +583,17 @@ func TestIPAddressPerTask(t *testing.T) {
 	ipPerTask := IPAddressPerTask{}
 	assert.Nil(t, ipPerTask.Groups)
 	assert.Nil(t, ipPerTask.Labels)
+	assert.Nil(t, ipPerTask.Discovery)
 
-	ipPerTask.AddGroup("label")
-	ipPerTask.AddLabel("key", "value")
+	ipPerTask.
+		AddGroup("label").
+		AddLabel("key", "value").
+		SetDiscovery(Discovery{})
 
 	assert.Equal(t, 1, len(*ipPerTask.Groups))
 	assert.Equal(t, "label", (*ipPerTask.Groups)[0])
 	assert.Equal(t, "value", (*ipPerTask.Labels)["key"])
+	assert.NotEmpty(t, ipPerTask.Discovery)
 
 	ipPerTask.EmptyGroups()
 	assert.Equal(t, 0, len(*ipPerTask.Groups))


### PR DESCRIPTION
The omitempty tag could not be effective since a non-pointer Discovery holds a nil Ports struct by default, thus making Discovery non-empty. This change corrects that.

We also add a test for SetDiscovery.

Fixes #241.