### PR TITLE
Fix unmarshalling of DeploymentPlan for Marathon v1.1.2+ API

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -60,47 +60,7 @@ type DeploymentPlan struct {
 	Version  	string            	`json:"version"`
 	Original 	*Group            	`json:"original"`
 	Target   	*Group            	`json:"target"`
-	Steps    	[]*DeploymentStep 	`json:"-"`
-	XXStepsRaw	json.RawMessage		`json:"steps"` // Holds raw steps JSON to unmarshal later
-}
-
-// Allows loading of deployment steps from the Marathon v1.X API
-func (d *DeploymentPlan) UnmarshalJSON(b []byte) error {
-	dp := &struct {
-		ID       	string            	`json:"id"`
-		Version  	string            	`json:"version"`
-		Original 	*Group            	`json:"original"`
-		Target   	*Group            	`json:"target"`
-		XXStepsRaw  json.RawMessage 	`json:"steps"`
-	}{}
-	err := json.Unmarshal(b, &dp)
-	if err != nil {
-		return err
-	}
-	d.ID = dp.ID
-	d.Version = dp.Version
-	d.Original = dp.Original
-	d.Target = dp.Target
-	var deploymentStepArray []*DeploymentStep
-	if len(dp.XXStepsRaw) != 0 {
-		err = json.Unmarshal(dp.XXStepsRaw, &deploymentStepArray)
-		if err != nil {
-			return err
-		}
-		d.Steps = deploymentStepArray
-	}
-	if len(d.Steps)>0 && d.Steps[0].Action == "" {
-		var stepActionsArray []*StepActions
-		err = json.Unmarshal(dp.XXStepsRaw, &stepActionsArray)
-		if err != nil {
-			return err
-		}
-		for stepIndex, step := range stepActionsArray {
-			d.Steps[stepIndex].Action = step.Actions[0].Type
-			d.Steps[stepIndex].App = step.Actions[0].App
-		}
-	}
-	return nil
+	Steps    	[]*StepActions 		`json:"steps"`
 }
 
 // Deployments retrieves a list of current deployments

--- a/deployment.go
+++ b/deployment.go
@@ -49,8 +49,9 @@ type DeploymentStep struct {
 // StepActions is a series of deployment steps
 type StepActions struct {
 	Actions []struct {
-		Type string `json:"type"`
-		App  string `json:"app"`
+		Action 	string	`json:"action"`	// 1.1.2 and after
+		Type 	string	`json:"type"`	// 1.1.1 and before
+		App  	string	`json:"app"`
 	}
 }
 
@@ -84,8 +85,14 @@ func (r *marathonClient) Deployments() ([]*Deployment, error) {
 			for stepIndex, step := range steps {
 				deployment.Steps = append(deployment.Steps, make([]*DeploymentStep, len(step.Actions)))
 				for actionIndex, action := range step.Actions {
+					var stepAction string
+					if (action.Type != "") {
+						stepAction = action.Type
+					} else {
+						stepAction = action.Action
+					}
 					deployment.Steps[stepIndex][actionIndex] = &DeploymentStep{
-						Action: action.Type,
+						Action: stepAction,
 						App:    action.App,
 					}
 				}

--- a/deployment.go
+++ b/deployment.go
@@ -49,9 +49,9 @@ type DeploymentStep struct {
 // StepActions is a series of deployment steps
 type StepActions struct {
 	Actions []struct {
-		Action 	string	`json:"action"`	// 1.1.2 and after
-		Type 	string	`json:"type"`	// 1.1.1 and before
-		App  	string	`json:"app"`
+		Action string `json:"action"` // 1.1.2 and after
+		Type   string `json:"type"`   // 1.1.1 and before
+		App    string `json:"app"`
 	}
 }
 
@@ -86,7 +86,7 @@ func (r *marathonClient) Deployments() ([]*Deployment, error) {
 				deployment.Steps = append(deployment.Steps, make([]*DeploymentStep, len(step.Actions)))
 				for actionIndex, action := range step.Actions {
 					var stepAction string
-					if (action.Type != "") {
+					if action.Type != "" {
 						stepAction = action.Type
 					} else {
 						stepAction = action.Action

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -170,9 +170,9 @@ var testCases = testCaseList{
 				Steps: []*StepActions{
 					&StepActions{
 						Actions: []struct {
-							Action	string	`json:"action"`
-							Type	string	`json:"type"`
-							App	string	`json:"app"`
+							Action string `json:"action"`
+							Type   string `json:"type"`
+							App    string `json:"app"`
 						}{
 							{
 								Type: "ScaleApplication",
@@ -184,9 +184,9 @@ var testCases = testCaseList{
 			},
 			CurrentStep: &StepActions{
 				Actions: []struct {
-					Action	string	`json:"action"`
-					Type	string	`json:"type"`
-					App	string	`json:"app"`
+					Action string `json:"action"`
+					Type   string `json:"type"`
+					App    string `json:"app"`
 				}{
 					{
 						Type: "ScaleApplication",
@@ -231,20 +231,20 @@ var testCases = testCaseList{
 			EventType: "deployment_info",
 			Timestamp: "2016-07-29T08:03:52.542Z",
 			Plan: &DeploymentPlan{
-				ID: "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
-				Version: "2016-07-29T08:03:52.542Z",
+				ID:       "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+				Version:  "2016-07-29T08:03:52.542Z",
 				Original: &Group{},
-				Target: &Group{},
+				Target:   &Group{},
 				Steps: []*StepActions{
 					&StepActions{
 						Actions: []struct {
-							Action	string	`json:"action"`
-							Type	string	`json:"type"`
-							App	string	`json:"app"`
+							Action string `json:"action"`
+							Type   string `json:"type"`
+							App    string `json:"app"`
 						}{
 							{
 								Action: "ScaleApplication",
-								App:  "/my-app",
+								App:    "/my-app",
 							},
 						},
 					},
@@ -252,13 +252,13 @@ var testCases = testCaseList{
 			},
 			CurrentStep: &StepActions{
 				Actions: []struct {
-					Action	string	`json:"action"`
-					Type	string	`json:"type"`
-					App	string	`json:"app"`
+					Action string `json:"action"`
+					Type   string `json:"type"`
+					App    string `json:"app"`
 				}{
 					{
 						Action: "ScaleApplication",
-						App:  "/my-app",
+						App:    "/my-app",
 					},
 				},
 			},

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -133,7 +133,18 @@ var testCases = testCaseList{
 		source: `{
 	"eventType": "deployment_info",
 	"timestamp": "2016-07-29T08:03:52.542Z",
-	"plan": {},
+	"plan": {
+		"id": "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+		"version": "2016-07-29T08:03:52.542Z",
+		"original": {},
+		"target": {},
+		"steps": [
+			{
+				"action": "ScaleApplication",
+				"app": "/my-app"
+			}
+		]
+	},
 	"currentStep": {
 		"actions": [
 			{
@@ -146,7 +157,77 @@ var testCases = testCaseList{
 		expectation: &EventDeploymentInfo{
 			EventType: "deployment_info",
 			Timestamp: "2016-07-29T08:03:52.542Z",
-			Plan:      &DeploymentPlan{},
+			Plan:      &DeploymentPlan{
+				ID: "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+				Version: "2016-07-29T08:03:52.542Z",
+				Original: &Group{},
+				Target: &Group{},
+				Steps: []*DeploymentStep {
+					{
+						Action: "ScaleApplication",
+						App: "/my-app",
+					},
+				},
+			},
+			CurrentStep: &StepActions{
+				Actions: []struct {
+					Type string `json:"type"`
+					App  string `json:"app"`
+				}{
+					{
+						Type: "ScaleApplication",
+						App:  "/my-app",
+					},
+				},
+			},
+		},
+	},
+	// For marathon 1.X
+	testCase{
+		name: "deployment_step_success",
+		source: `{
+	"eventType": "deployment_step_success",
+	"timestamp": "2016-09-29T03:15:40.176Z",
+	"plan": {
+		"id": "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+		"version": "2016-09-29T03:15:40.176Z",
+		"original": {},
+		"target": {},
+		"steps": [
+			{
+				"actions": [
+					{
+						"type": "ScaleApplication",
+						"app": "/my-app"
+					}
+				]
+			}
+		]
+	},
+	"currentStep": {
+		"actions": [
+			{
+				"type": "ScaleApplication",
+				"app": "/my-app"
+			}
+		]
+	}
+}`,
+		expectation: &EventDeploymentStepSuccess{
+			EventType: "deployment_step_success",
+			Timestamp: "2016-09-29T03:15:40.176Z",
+			Plan:      &DeploymentPlan{
+				ID: "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+				Version: "2016-09-29T03:15:40.176Z",
+				Original: &Group{},
+				Target: &Group{},
+				Steps: []*DeploymentStep {
+					{
+						Action: "ScaleApplication",
+						App: "/my-app",
+					},
+				},
+			},
 			CurrentStep: &StepActions{
 				Actions: []struct {
 					Type string `json:"type"`
@@ -220,7 +301,7 @@ func TestEventStreamEventsReceived(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, &config)
 	defer endpoint.Close()
 
-	events, err := endpoint.Client.AddEventsListener(EventIDApplications | EventIDDeploymentInfo)
+	events, err := endpoint.Client.AddEventsListener(EventIDApplications | EventIDDeploymentInfo | EventIDDeploymentStepSuccess)
 	assert.NoError(t, err)
 
 	almostAllTestCases := testCases[:len(testCases)-1]

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -140,8 +140,12 @@ var testCases = testCaseList{
 		"target": {},
 		"steps": [
 			{
-				"action": "ScaleApplication",
-				"app": "/my-app"
+				"actions": [
+					{
+						"type": "ScaleApplication",
+						"app": "/my-app"
+					}
+				]
 			}
 		]
 	},
@@ -162,69 +166,17 @@ var testCases = testCaseList{
 				Version: "2016-07-29T08:03:52.542Z",
 				Original: &Group{},
 				Target: &Group{},
-				Steps: []*DeploymentStep {
-					{
-						Action: "ScaleApplication",
-						App: "/my-app",
-					},
-				},
-			},
-			CurrentStep: &StepActions{
-				Actions: []struct {
-					Type string `json:"type"`
-					App  string `json:"app"`
-				}{
-					{
-						Type: "ScaleApplication",
-						App:  "/my-app",
-					},
-				},
-			},
-		},
-	},
-	// For marathon 1.X
-	testCase{
-		name: "deployment_step_success",
-		source: `{
-	"eventType": "deployment_step_success",
-	"timestamp": "2016-09-29T03:15:40.176Z",
-	"plan": {
-		"id": "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
-		"version": "2016-09-29T03:15:40.176Z",
-		"original": {},
-		"target": {},
-		"steps": [
-			{
-				"actions": [
-					{
-						"type": "ScaleApplication",
-						"app": "/my-app"
-					}
-				]
-			}
-		]
-	},
-	"currentStep": {
-		"actions": [
-			{
-				"type": "ScaleApplication",
-				"app": "/my-app"
-			}
-		]
-	}
-}`,
-		expectation: &EventDeploymentStepSuccess{
-			EventType: "deployment_step_success",
-			Timestamp: "2016-09-29T03:15:40.176Z",
-			Plan:      &DeploymentPlan{
-				ID: "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
-				Version: "2016-09-29T03:15:40.176Z",
-				Original: &Group{},
-				Target: &Group{},
-				Steps: []*DeploymentStep {
-					{
-						Action: "ScaleApplication",
-						App: "/my-app",
+				Steps: []*StepActions{
+					&StepActions{
+						Actions: []struct {
+							Type string `json:"type"`
+							App  string `json:"app"`
+						}{
+							{
+								Type: "ScaleApplication",
+								App:  "/my-app",
+							},
+						},
 					},
 				},
 			},
@@ -301,7 +253,7 @@ func TestEventStreamEventsReceived(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, &config)
 	defer endpoint.Close()
 
-	events, err := endpoint.Client.AddEventsListener(EventIDApplications | EventIDDeploymentInfo | EventIDDeploymentStepSuccess)
+	events, err := endpoint.Client.AddEventsListener(EventIDApplications | EventIDDeploymentInfo)
 	assert.NoError(t, err)
 
 	almostAllTestCases := testCases[:len(testCases)-1]

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -128,6 +128,7 @@ var testCases = testCaseList{
 			},
 		},
 	},
+	// For Marathon 1.1.1 and before
 	testCase{
 		name: "deployment_info",
 		source: `{
@@ -169,8 +170,9 @@ var testCases = testCaseList{
 				Steps: []*StepActions{
 					&StepActions{
 						Actions: []struct {
-							Type string `json:"type"`
-							App  string `json:"app"`
+							Action	string	`json:"action"`
+							Type	string	`json:"type"`
+							App	string	`json:"app"`
 						}{
 							{
 								Type: "ScaleApplication",
@@ -182,11 +184,80 @@ var testCases = testCaseList{
 			},
 			CurrentStep: &StepActions{
 				Actions: []struct {
-					Type string `json:"type"`
-					App  string `json:"app"`
+					Action	string	`json:"action"`
+					Type	string	`json:"type"`
+					App	string	`json:"app"`
 				}{
 					{
 						Type: "ScaleApplication",
+						App:  "/my-app",
+					},
+				},
+			},
+		},
+	},
+	// For Marathon 1.1.2 and after
+	testCase{
+		name: "deployment_step_success",
+		source: `{
+	"eventType": "deployment_step_success",
+	"timestamp": "2016-07-29T08:03:52.542Z",
+	"plan": {
+		"id": "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+		"version": "2016-07-29T08:03:52.542Z",
+		"original": {},
+		"target": {},
+		"steps": [
+			{
+				"actions": [
+					{
+						"action": "ScaleApplication",
+						"app": "/my-app"
+					}
+				]
+			}
+		]
+	},
+	"currentStep": {
+		"actions": [
+			{
+				"action": "ScaleApplication",
+				"app": "/my-app"
+			}
+		]
+	}
+}`,
+		expectation: &EventDeploymentInfo{
+			EventType: "deployment_info",
+			Timestamp: "2016-07-29T08:03:52.542Z",
+			Plan: &DeploymentPlan{
+				ID: "dcf63e4a-ef27-4816-e865-1730fcb26ac3",
+				Version: "2016-07-29T08:03:52.542Z",
+				Original: &Group{},
+				Target: &Group{},
+				Steps: []*StepActions{
+					&StepActions{
+						Actions: []struct {
+							Action	string	`json:"action"`
+							Type	string	`json:"type"`
+							App	string	`json:"app"`
+						}{
+							{
+								Action: "ScaleApplication",
+								App:  "/my-app",
+							},
+						},
+					},
+				},
+			},
+			CurrentStep: &StepActions{
+				Actions: []struct {
+					Action	string	`json:"action"`
+					Type	string	`json:"type"`
+					App	string	`json:"app"`
+				}{
+					{
+						Action: "ScaleApplication",
 						App:  "/my-app",
 					},
 				},
@@ -253,7 +324,7 @@ func TestEventStreamEventsReceived(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, &config)
 	defer endpoint.Close()
 
-	events, err := endpoint.Client.AddEventsListener(EventIDApplications | EventIDDeploymentInfo)
+	events, err := endpoint.Client.AddEventsListener(EventIDApplications | EventIDDeploymentInfo | EventIDDeploymentStepSuccess)
 	assert.NoError(t, err)
 
 	almostAllTestCases := testCases[:len(testCases)-1]


### PR DESCRIPTION
Following PR #215 , it's quite annoying after we updated marathon from v1.1.1 to v1.1.2, a deployment plan message has changed from
```
{
  ...
  "plan": {
    ...
    "steps": [
      {
        "actions": [
          {
            "type": "ScaleApplication",
            "app": "/my-app"
          }
        ]
      }
    ],
    "version": "2016-09-23T03:22:17.119Z"
  },
  "currentStep": {
    "actions": [
      {
        "type": "ScaleApplication",
        "app": "/my-app"
      }
    ]
  },
}
```
to
```
{
  ...
  "plan": {
    ...
    "steps": [
      {
        "actions": [
          {
            "action": "ScaleApplication",
            "app": "/my-app"
          }
        ]
      }
    ],
    "version": "2016-09-23T03:22:17.119Z"
  },
  "currentStep": {
    "actions": [
      {
        "action": "ScaleApplication",
        "app": "/my-app"
      }
    ]
  },
}
```
Even though, I try to keep the attribute `Type` for compatibility, please check if it's ok.

Thanks.