### PR TITLE
Add DCOS path parameter for additional marathon instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [#267][PR267] Add DCOS path parameter for additional marathon instances.
 
 ## [0.7.1] - 2017-02-20
 ### Fixed
@@ -118,6 +120,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [0.1.1]: https://github.com/gambol99/go-marathon/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/gambol99/go-marathon/compare/v0.0.1...v0.1.0
 
+[PR267]: https://github.com/gambol99/go-marathon/pull/267
 [PR261]: https://github.com/gambol99/go-marathon/pull/261
 [PR259]: https://github.com/gambol99/go-marathon/pull/259
 [PR256]: https://github.com/gambol99/go-marathon/pull/256

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ marathonURL := "http://10.241.1.71:8080,10.241.1.72:8080,10.241.1.73:8080"
 The first one specified will be used, if that goes offline the member is marked as *"unavailable"* and a
 background process will continue to ping the member until it's back online.
 
+You can also pass a custom path to the URL, which is especially needed in case of DCOS:
+
+```Go
+marathonURL := "http://10.241.1.71:8080/cluster,10.241.1.72:8080/cluster,10.241.1.73:8080/cluster"
+```
+
+If you specify a `DCOSToken` in the configuration file but do not pass a custom URL path, `/marathon` will be used.
+
 ### Custom HTTP Client
 
 If you wish to override the http client (by default http.DefaultClient) used by the API; use cases bypassing TLS verification, load root CA's or change the timeouts etc, you can pass a custom client in the config.

--- a/client.go
+++ b/client.go
@@ -256,7 +256,9 @@ func (r *marathonClient) apiCall(method, uri string, body, result interface{}) e
 
 		// step: Create the endpoint url
 		url := fmt.Sprintf("%s/%s", member, uri)
-		if r.config.DCOSToken != "" {
+		if r.config.DCOSToken != "" && r.config.DCOSPath != "" {
+			url = fmt.Sprintf("%s/%s/%s", member, r.config.DCOSPath, uri)
+		} else if r.config.DCOSToken != "" {
 			url = fmt.Sprintf("%s/%s", member+"/marathon", uri)
 		}
 

--- a/client.go
+++ b/client.go
@@ -197,8 +197,13 @@ func NewClient(config Config) (Marathon, error) {
 		config.PollingWaitTime = defaultPollingWaitTime
 	}
 
+	// step: if DCOSToken is set and DCOSPath is not, set DCOSPath to default value
+	if config.DCOSToken != "" && config.DCOSPath == "" {
+		config.DCOSPath = defaultDCOSPath
+	}
+
 	// step: create a new cluster
-	hosts, err := newCluster(config.HTTPClient, config.URL)
+	hosts, err := newCluster(config.HTTPClient, config.URL, config.DCOSPath)
 	if err != nil {
 		return nil, err
 	}
@@ -256,11 +261,6 @@ func (r *marathonClient) apiCall(method, uri string, body, result interface{}) e
 
 		// step: Create the endpoint url
 		url := fmt.Sprintf("%s/%s", member, uri)
-		if r.config.DCOSToken != "" && r.config.DCOSPath != "" {
-			url = fmt.Sprintf("%s/%s/%s", member, r.config.DCOSPath, uri)
-		} else if r.config.DCOSToken != "" {
-			url = fmt.Sprintf("%s/%s", member+"/marathon", uri)
-		}
 
 		// step: marshall the request to json
 		var requestBody []byte

--- a/client.go
+++ b/client.go
@@ -197,13 +197,8 @@ func NewClient(config Config) (Marathon, error) {
 		config.PollingWaitTime = defaultPollingWaitTime
 	}
 
-	// step: if DCOSToken is set and DCOSPath is not, set DCOSPath to default value
-	if config.DCOSToken != "" && config.DCOSPath == "" {
-		config.DCOSPath = defaultDCOSPath
-	}
-
 	// step: create a new cluster
-	hosts, err := newCluster(config.HTTPClient, config.URL, config.DCOSPath)
+	hosts, err := newCluster(config.HTTPClient, config.URL, config.DCOSToken != "")
 	if err != nil {
 		return nil, err
 	}
@@ -251,19 +246,11 @@ func (r *marathonClient) apiDelete(uri string, post, result interface{}) error {
 	return r.apiCall("DELETE", uri, post, result)
 }
 
-func (r *marathonClient) apiCall(method, uri string, body, result interface{}) error {
+func (r *marathonClient) apiCall(method, url string, body, result interface{}) error {
 	for {
-		// step: grab a member from the cluster and attempt to perform the request
-		member, err := r.hosts.getMember()
-		if err != nil {
-			return ErrMarathonDown
-		}
-
-		// step: Create the endpoint url
-		url := fmt.Sprintf("%s/%s", member, uri)
-
 		// step: marshall the request to json
 		var requestBody []byte
+		var err error
 		if body != nil {
 			if requestBody, err = json.Marshal(body); err != nil {
 				return err
@@ -271,7 +258,7 @@ func (r *marathonClient) apiCall(method, uri string, body, result interface{}) e
 		}
 
 		// step: create the api request
-		request, err := r.buildAPIRequest(method, url, bytes.NewReader(requestBody))
+		request, member, err := r.buildAPIRequest(method, url, bytes.NewReader(requestBody))
 		if err != nil {
 			return err
 		}
@@ -320,11 +307,20 @@ func (r *marathonClient) apiCall(method, uri string, body, result interface{}) e
 }
 
 // buildAPIRequest creates a default API request
-func (r *marathonClient) buildAPIRequest(method, url string, reader io.Reader) (*http.Request, error) {
-	// Make the http request to Marathon
-	request, err := http.NewRequest(method, url, reader)
+func (r *marathonClient) buildAPIRequest(method, uri string, reader io.Reader) (request *http.Request, member string, err error) {
+	// Grab a member from the cluster
+	member, err = r.hosts.getMember()
 	if err != nil {
-		return nil, err
+		return nil, "", ErrMarathonDown
+	}
+
+	// Create the endpoint URL
+	url := fmt.Sprintf("%s/%s", member, uri)
+
+	// Make the http request to Marathon
+	request, err = http.NewRequest(method, url, reader)
+	if err != nil {
+		return nil, member, err
 	}
 
 	// Add any basic auth and the content headers
@@ -339,7 +335,7 @@ func (r *marathonClient) buildAPIRequest(method, url string, reader io.Reader) (
 	request.Header.Add("Content-Type", "application/json")
 	request.Header.Add("Accept", "application/json")
 
-	return request, nil
+	return request, member, nil
 }
 
 var oneLogLineRegex = regexp.MustCompile(`(?m)^\s*`)

--- a/client_test.go
+++ b/client_test.go
@@ -39,6 +39,49 @@ func TestNewClient(t *testing.T) {
 	assert.Equal(t, conf.PollingWaitTime, defaultPollingWaitTime)
 }
 
+func TestDCOSPath(t *testing.T) {
+	cases := []struct {
+		DCOSToken string
+		DCOSPath  string
+		dcosPath  string
+	}{
+		{
+			DCOSToken: "",
+			DCOSPath:  "",
+			dcosPath:  "",
+		},
+		{
+			DCOSToken: "abcde",
+			DCOSPath:  "",
+			dcosPath:  defaultDCOSPath,
+		},
+		{
+			DCOSToken: "abcde",
+			DCOSPath:  "marathon-alice",
+			dcosPath:  "marathon-alice",
+		},
+	}
+
+	for _, x := range cases {
+
+		config := Config{
+			URL:       "http://127.0.0.1",
+			DCOSToken: x.DCOSToken,
+			DCOSPath:  x.DCOSPath,
+		}
+
+		cl, err := NewClient(config)
+
+		if !assert.Nil(t, err) {
+			return
+		}
+
+		conf := cl.(*marathonClient).config
+
+		assert.Equal(t, conf.DCOSPath, x.dcosPath)
+	}
+}
+
 func TestPing(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, nil)
 	defer endpoint.Close()

--- a/client_test.go
+++ b/client_test.go
@@ -39,49 +39,6 @@ func TestNewClient(t *testing.T) {
 	assert.Equal(t, conf.PollingWaitTime, defaultPollingWaitTime)
 }
 
-func TestDCOSPath(t *testing.T) {
-	cases := []struct {
-		DCOSToken string
-		DCOSPath  string
-		dcosPath  string
-	}{
-		{
-			DCOSToken: "",
-			DCOSPath:  "",
-			dcosPath:  "",
-		},
-		{
-			DCOSToken: "abcde",
-			DCOSPath:  "",
-			dcosPath:  defaultDCOSPath,
-		},
-		{
-			DCOSToken: "abcde",
-			DCOSPath:  "marathon-alice",
-			dcosPath:  "marathon-alice",
-		},
-	}
-
-	for _, x := range cases {
-
-		config := Config{
-			URL:       "http://127.0.0.1",
-			DCOSToken: x.DCOSToken,
-			DCOSPath:  x.DCOSPath,
-		}
-
-		cl, err := NewClient(config)
-
-		if !assert.Nil(t, err) {
-			return
-		}
-
-		conf := cl.(*marathonClient).config
-
-		assert.Equal(t, conf.DCOSPath, x.dcosPath)
-	}
-}
-
 func TestPing(t *testing.T) {
 	endpoint := newFakeMarathonEndpoint(t, nil)
 	defer endpoint.Close()

--- a/cluster.go
+++ b/cluster.go
@@ -51,7 +51,7 @@ type member struct {
 }
 
 // newCluster returns a new marathon cluster
-func newCluster(client *http.Client, marathonURL string) (*cluster, error) {
+func newCluster(client *http.Client, marathonURL string, DCOSPath string) (*cluster, error) {
 	// step: extract and basic validate the endpoints
 	var members []*member
 	var defaultProto string
@@ -69,6 +69,12 @@ func newCluster(client *http.Client, marathonURL string) (*cluster, error) {
 
 			endpoint = fmt.Sprintf("%s://%s", defaultProto, endpoint)
 		}
+
+		// step: if DCOSPath is set add it to marathonURL
+		if DCOSPath != "" {
+			endpoint = endpoint + "/" + DCOSPath
+		}
+
 		// step: parse the url
 		u, err := url.Parse(endpoint)
 		if err != nil {

--- a/config.go
+++ b/config.go
@@ -25,6 +25,8 @@ import (
 
 const defaultPollingWaitTime = 500 * time.Millisecond
 
+const defaultDCOSPath = "marathon"
+
 // EventsTransport describes which transport should be used to deliver Marathon events
 type EventsTransport int
 

--- a/config.go
+++ b/config.go
@@ -48,8 +48,6 @@ type Config struct {
 	CallbackURL string
 	// DCOSToken for DCOS environment, This will override the Authorization header
 	DCOSToken string
-	// DCOSPath for additional marathon instances
-	DCOSPath string
 	// LogOutput the output for debug log messages
 	LogOutput io.Writer
 	// HTTPClient is the http client

--- a/config.go
+++ b/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	CallbackURL string
 	// DCOSToken for DCOS environment, This will override the Authorization header
 	DCOSToken string
+	// DCOSPath for additional marathon instances
+	DCOSPath string
 	// LogOutput the output for debug log messages
 	LogOutput io.Writer
 	// HTTPClient is the http client

--- a/subscription.go
+++ b/subscription.go
@@ -167,13 +167,8 @@ func (r *marathonClient) registerSSESubscription() error {
 	if r.subscribedToSSE {
 		return nil
 	}
-	// Get a member from the cluster
-	marathon, err := r.hosts.getMember()
-	if err != nil {
-		return err
-	}
 
-	request, err := r.buildAPIRequest("GET", fmt.Sprintf("%s/%s", marathon, marathonAPIEventStream), nil)
+	request, _, err := r.buildAPIRequest("GET", marathonAPIEventStream, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
You can install multiple instances of Marathon on DCOS [1] and you can also customize the DCOS path [2]. I'd like to be able to target these marathon instances but the path is hard-coded to **/marathon** [here](https://github.com/gambol99/go-marathon/blob/b307c574d90c358369555b8c694ac85cff4e76ac/client.go#L260):

```
		if r.config.DCOSToken != "" {
			url = fmt.Sprintf("%s/%s", member+"/marathon", uri)
		}
```

We could include a configuration parameter **DCOSPath** and change code that creates the URL to:

```
                if r.config.DCOSToken != "" && r.config.DCOSPath != "" {
                        url = fmt.Sprintf("%s/%s/%s", member, r.config.DCOSPath, uri)
                } else if r.config.DCOSToken != "" {
                        url = fmt.Sprintf("%s/%s", member+"/marathon", uri)
                }
```

The DCOS URL follows this format: *&lt;dcos-url>/service/&lt;name-of-additional-marathon-instance>*, so if your marathon instance is named *marathon-alice* you need to set the **DCOSPath** to *service/marathon-alice*.

[1] [Install Multiple Additional Marathon Instances](https://docs.mesosphere.com/1.8/usage/service-guides/marathon/install/#scrollNav-2)
[2] [Default InstallationAdminister Additional Marathon Instances via the DC/OS CLI](https://docs.mesosphere.com/1.8/usage/service-guides/marathon/install/#scrollNav-3)