### PR TITLE
fix ping request in healthCheckNode

### DIFF
--- a/application.go
+++ b/application.go
@@ -455,7 +455,7 @@ func (r *Application) DeploymentIDs() []*DeploymentID {
 // CheckHTTP adds a HTTP check to an application
 //		port: 		the port the check should be checking
 // 		interval:	the interval in seconds the check should be performed
-func (r *Application) CheckHTTP(uri string, port, interval int) (*Application, error) {
+func (r *Application) CheckHTTP(path string, port, interval int) (*Application, error) {
 	if r.Container == nil || r.Container.Docker == nil {
 		return nil, ErrNoApplicationContainer
 	}
@@ -466,7 +466,7 @@ func (r *Application) CheckHTTP(uri string, port, interval int) (*Application, e
 	}
 	health := NewDefaultHealthCheck()
 	health.IntervalSeconds = interval
-	*health.Path = uri
+	*health.Path = path
 	*health.PortIndex = portIndex
 	// step: add to the checks
 	r.AddHealthCheck(*health)
@@ -627,9 +627,9 @@ func (r *marathonClient) HasApplicationVersion(name, version string) (bool, erro
 // ApplicationVersions is a list of versions which has been deployed with marathon for a specific application
 //		name:		the id used to identify the application
 func (r *marathonClient) ApplicationVersions(name string) (*ApplicationVersions, error) {
-	uri := fmt.Sprintf("%s/versions", buildURI(name))
+	path := fmt.Sprintf("%s/versions", buildPath(name))
 	versions := new(ApplicationVersions)
-	if err := r.apiGet(uri, nil, versions); err != nil {
+	if err := r.apiGet(path, nil, versions); err != nil {
 		return nil, err
 	}
 	return versions, nil
@@ -639,9 +639,9 @@ func (r *marathonClient) ApplicationVersions(name string) (*ApplicationVersions,
 // 		name: 		the id used to identify the application
 //		version: 	the version (normally a timestamp) you wish to change to
 func (r *marathonClient) SetApplicationVersion(name string, version *ApplicationVersion) (*DeploymentID, error) {
-	uri := fmt.Sprintf(buildURI(name))
+	path := fmt.Sprintf(buildPath(name))
 	deploymentID := new(DeploymentID)
-	if err := r.apiPut(uri, version, deploymentID); err != nil {
+	if err := r.apiPut(path, version, deploymentID); err != nil {
 		return nil, err
 	}
 
@@ -655,7 +655,7 @@ func (r *marathonClient) Application(name string) (*Application, error) {
 		Application *Application `json:"app"`
 	}
 
-	if err := r.apiGet(buildURI(name), nil, &wrapper); err != nil {
+	if err := r.apiGet(buildPath(name), nil, &wrapper); err != nil {
 		return nil, err
 	}
 
@@ -666,7 +666,7 @@ func (r *marathonClient) Application(name string) (*Application, error) {
 // 		name: 		the id used to identify the application
 //		opts:		GetAppOpts request payload
 func (r *marathonClient) ApplicationBy(name string, opts *GetAppOpts) (*Application, error) {
-	u, err := addOptions(buildURI(name), opts)
+	path, err := addOptions(buildPath(name), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -674,7 +674,7 @@ func (r *marathonClient) ApplicationBy(name string, opts *GetAppOpts) (*Applicat
 		Application *Application `json:"app"`
 	}
 
-	if err := r.apiGet(u, nil, &wrapper); err != nil {
+	if err := r.apiGet(path, nil, &wrapper); err != nil {
 		return nil, err
 	}
 
@@ -687,8 +687,8 @@ func (r *marathonClient) ApplicationBy(name string, opts *GetAppOpts) (*Applicat
 func (r *marathonClient) ApplicationByVersion(name, version string) (*Application, error) {
 	app := new(Application)
 
-	uri := fmt.Sprintf("%s/versions/%s", buildURI(name), version)
-	if err := r.apiGet(uri, nil, app); err != nil {
+	path := fmt.Sprintf("%s/versions/%s", buildPath(name), version)
+	if err := r.apiGet(path, nil, app); err != nil {
 		return nil, err
 	}
 
@@ -795,10 +795,10 @@ func (r *marathonClient) appExistAndRunning(name string) bool {
 // 		name: 		the id used to identify the application
 //		force:		used to force the delete operation in case of blocked deployment
 func (r *marathonClient) DeleteApplication(name string, force bool) (*DeploymentID, error) {
-	uri := buildURIWithForceParam(name, force)
+	path := buildPathWithForceParam(name, force)
 	// step: check of the application already exists
 	deployID := new(DeploymentID)
-	if err := r.apiDelete(uri, nil, deployID); err != nil {
+	if err := r.apiDelete(path, nil, deployID); err != nil {
 		return nil, err
 	}
 
@@ -810,8 +810,8 @@ func (r *marathonClient) DeleteApplication(name string, force bool) (*Deployment
 func (r *marathonClient) RestartApplication(name string, force bool) (*DeploymentID, error) {
 	deployment := new(DeploymentID)
 	var options struct{}
-	uri := buildURIWithForceParam(fmt.Sprintf("%s/restart", name), force)
-	if err := r.apiPost(uri, &options, deployment); err != nil {
+	path := buildPathWithForceParam(fmt.Sprintf("%s/restart", name), force)
+	if err := r.apiPost(path, &options, deployment); err != nil {
 		return nil, err
 	}
 
@@ -826,9 +826,9 @@ func (r *marathonClient) ScaleApplicationInstances(name string, instances int, f
 	changes := new(Application)
 	changes.ID = validateID(name)
 	changes.Instances = &instances
-	uri := buildURIWithForceParam(name, force)
+	path := buildPathWithForceParam(name, force)
 	deployID := new(DeploymentID)
-	if err := r.apiPut(uri, changes, deployID); err != nil {
+	if err := r.apiPut(path, changes, deployID); err != nil {
 		return nil, err
 	}
 
@@ -839,22 +839,22 @@ func (r *marathonClient) ScaleApplicationInstances(name string, instances int, f
 // 		application:		the structure holding the application configuration
 func (r *marathonClient) UpdateApplication(application *Application, force bool) (*DeploymentID, error) {
 	result := new(DeploymentID)
-	uri := buildURIWithForceParam(application.ID, force)
-	if err := r.apiPut(uri, application, result); err != nil {
+	path := buildPathWithForceParam(application.ID, force)
+	if err := r.apiPut(path, application, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func buildURIWithForceParam(path string, force bool) string {
-	uri := buildURI(path)
+func buildPathWithForceParam(rootPath string, force bool) string {
+	path := buildPath(rootPath)
 	if force {
-		uri += "?force=true"
+		path += "?force=true"
 	}
-	return uri
+	return path
 }
 
-func buildURI(path string) string {
+func buildPath(path string) string {
 	return fmt.Sprintf("%s/%s", marathonAPIApps, trimRootPath(path))
 }
 

--- a/client.go
+++ b/client.go
@@ -238,23 +238,23 @@ func (r *marathonClient) Ping() (bool, error) {
 	return true, nil
 }
 
-func (r *marathonClient) apiGet(uri string, post, result interface{}) error {
-	return r.apiCall("GET", uri, post, result)
+func (r *marathonClient) apiGet(path string, post, result interface{}) error {
+	return r.apiCall("GET", path, post, result)
 }
 
-func (r *marathonClient) apiPut(uri string, post, result interface{}) error {
-	return r.apiCall("PUT", uri, post, result)
+func (r *marathonClient) apiPut(path string, post, result interface{}) error {
+	return r.apiCall("PUT", path, post, result)
 }
 
-func (r *marathonClient) apiPost(uri string, post, result interface{}) error {
-	return r.apiCall("POST", uri, post, result)
+func (r *marathonClient) apiPost(path string, post, result interface{}) error {
+	return r.apiCall("POST", path, post, result)
 }
 
-func (r *marathonClient) apiDelete(uri string, post, result interface{}) error {
-	return r.apiCall("DELETE", uri, post, result)
+func (r *marathonClient) apiDelete(path string, post, result interface{}) error {
+	return r.apiCall("DELETE", path, post, result)
 }
 
-func (r *marathonClient) apiCall(method, url string, body, result interface{}) error {
+func (r *marathonClient) apiCall(method, path string, body, result interface{}) error {
 	for {
 		// step: marshall the request to json
 		var requestBody []byte
@@ -266,7 +266,7 @@ func (r *marathonClient) apiCall(method, url string, body, result interface{}) e
 		}
 
 		// step: create the API request
-		request, member, err := r.buildAPIRequest(method, url, bytes.NewReader(requestBody))
+		request, member, err := r.buildAPIRequest(method, path, bytes.NewReader(requestBody))
 		if err != nil {
 			return err
 		}
@@ -317,7 +317,7 @@ func (r *marathonClient) apiCall(method, url string, body, result interface{}) e
 }
 
 // buildAPIRequest creates a default API request
-func (r *marathonClient) buildAPIRequest(method, uri string, reader io.Reader) (request *http.Request, member string, err error) {
+func (r *marathonClient) buildAPIRequest(method, path string, reader io.Reader) (request *http.Request, member string, err error) {
 	// Grab a member from the cluster
 	member, err = r.hosts.getMember()
 	if err != nil {
@@ -325,16 +325,16 @@ func (r *marathonClient) buildAPIRequest(method, uri string, reader io.Reader) (
 	}
 
 	// Build the HTTP request to Marathon
-	request, err = r.client.buildMarathonRequest(method, member, uri, reader)
+	request, err = r.client.buildMarathonRequest(method, member, path, reader)
 	if err != nil {
 		return nil, member, err
 	}
 	return request, member, nil
 }
 
-func (rc *httpClient) buildMarathonRequest(method string, member string, uri string, reader io.Reader) (request *http.Request, err error) {
+func (rc *httpClient) buildMarathonRequest(method string, member string, path string, reader io.Reader) (request *http.Request, err error) {
 	// Create the endpoint URL
-	url := fmt.Sprintf("%s/%s", member, uri)
+	url := fmt.Sprintf("%s/%s", member, path)
 
 	// Instantiate an HTTP request
 	request, err = http.NewRequest(method, url, reader)

--- a/client.go
+++ b/client.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 )
@@ -332,7 +333,13 @@ func (r *marathonClient) buildAPIRequest(method, path string, reader io.Reader) 
 	return request, member, nil
 }
 
+// buildMarathonRequest creates a new HTTP request and configures it according to the *httpClient configuration.
+// The path must not contain a leading "/", otherwise buildMarathonRequest will panic.
 func (rc *httpClient) buildMarathonRequest(method string, member string, path string, reader io.Reader) (request *http.Request, err error) {
+	if strings.HasPrefix(path, "/") {
+		panic(fmt.Sprintf("Path '%s' must not start with a leading slash", path))
+	}
+
 	// Create the endpoint URL
 	url := fmt.Sprintf("%s/%s", member, path)
 

--- a/cluster.go
+++ b/cluster.go
@@ -131,7 +131,7 @@ func (c *cluster) markDown(endpoint string) {
 func (c *cluster) healthCheckNode(node *member) {
 	// step: wait for the node to become active ... we are assuming a /ping is enough here
 	for {
-		req, err := c.client.buildMarathonRequest("GET", node.endpoint, "/ping", nil)
+		req, err := c.client.buildMarathonRequest("GET", node.endpoint, "ping", nil)
 		if err == nil {
 			res, err := c.client.Do(req)
 			if err == nil && res.StatusCode == 200 {

--- a/group.go
+++ b/group.go
@@ -106,12 +106,12 @@ func (r *marathonClient) Group(name string) (*Group, error) {
 // GroupsBy retrieves a list of all the groups from marathon by embed options
 //		opts:		GetGroupOpts request payload
 func (r *marathonClient) GroupsBy(opts *GetGroupOpts) (*Groups, error) {
-	u, err := addOptions(marathonAPIGroups, opts)
+	path, err := addOptions(marathonAPIGroups, opts)
 	if err != nil {
 		return nil, err
 	}
 	groups := new(Groups)
-	if err := r.apiGet(u, "", groups); err != nil {
+	if err := r.apiGet(path, "", groups); err != nil {
 		return nil, err
 	}
 	return groups, nil
@@ -121,12 +121,12 @@ func (r *marathonClient) GroupsBy(opts *GetGroupOpts) (*Groups, error) {
 //		name:			the identifier for the group
 //		opts:			GetGroupOpts request payload
 func (r *marathonClient) GroupBy(name string, opts *GetGroupOpts) (*Group, error) {
-	u, err := addOptions(fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name)), opts)
+	path, err := addOptions(fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name)), opts)
 	if err != nil {
 		return nil, err
 	}
 	group := new(Group)
-	if err := r.apiGet(u, nil, group); err != nil {
+	if err := r.apiGet(path, nil, group); err != nil {
 		return nil, err
 	}
 	return group, nil
@@ -135,8 +135,8 @@ func (r *marathonClient) GroupBy(name string, opts *GetGroupOpts) (*Group, error
 // HasGroup checks if the group exists in marathon
 // 		name:			the identifier for the group
 func (r *marathonClient) HasGroup(name string) (bool, error) {
-	uri := fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name))
-	err := r.apiCall("GET", uri, "", nil)
+	path := fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name))
+	err := r.apiCall("GET", path, "", nil)
 	if err != nil {
 		if apiErr, ok := err.(*APIError); ok && apiErr.ErrCode == ErrCodeNotFound {
 			return false, nil
@@ -208,11 +208,9 @@ func (r *marathonClient) WaitOnGroup(name string, timeout time.Duration) error {
 //		force:			used to force the delete operation in case of blocked deployment
 func (r *marathonClient) DeleteGroup(name string, force bool) (*DeploymentID, error) {
 	version := new(DeploymentID)
-	uri := fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name))
-	if force {
-		uri = uri + "?force=true"
-	}
-	if err := r.apiDelete(uri, nil, version); err != nil {
+	path := fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name))
+	path = buildPathWithForceParam(path, force)
+	if err := r.apiDelete(path, nil, version); err != nil {
 		return nil, err
 	}
 
@@ -225,11 +223,9 @@ func (r *marathonClient) DeleteGroup(name string, force bool) (*DeploymentID, er
 //		force:			used to force the update operation in case of blocked deployment
 func (r *marathonClient) UpdateGroup(name string, group *Group, force bool) (*DeploymentID, error) {
 	deploymentID := new(DeploymentID)
-	uri := fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name))
-	if force {
-		uri = uri + "?force=true"
-	}
-	if err := r.apiPut(uri, group, deploymentID); err != nil {
+	path := fmt.Sprintf("%s/%s", marathonAPIGroups, trimRootPath(name))
+	path = buildPathWithForceParam(path, force)
+	if err := r.apiPut(path, group, deploymentID); err != nil {
 		return nil, err
 	}
 

--- a/queue.go
+++ b/queue.go
@@ -51,8 +51,8 @@ func (r *marathonClient) Queue() (*Queue, error) {
 // DeleteQueueDelay resets task launch delay of the specific application
 //		appID:		the ID of the application
 func (r *marathonClient) DeleteQueueDelay(appID string) error {
-	uri := fmt.Sprintf("%s/%s/delay", marathonAPIQueue, trimRootPath(appID))
-	err := r.apiDelete(uri, nil, nil)
+	path := fmt.Sprintf("%s/%s/delay", marathonAPIQueue, trimRootPath(appID))
+	err := r.apiDelete(path, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/subscription.go
+++ b/subscription.go
@@ -201,8 +201,8 @@ func (r *marathonClient) registerSSESubscription() error {
 // Subscribe adds a URL to Marathon's callback facility
 //	callback	: the URL you wish to subscribe
 func (r *marathonClient) Subscribe(callback string) error {
-	uri := fmt.Sprintf("%s?callbackUrl=%s", marathonAPISubscription, callback)
-	return r.apiPost(uri, "", nil)
+	path := fmt.Sprintf("%s?callbackUrl=%s", marathonAPISubscription, callback)
+	return r.apiPost(path, "", nil)
 
 }
 

--- a/task.go
+++ b/task.go
@@ -79,13 +79,13 @@ func (r *Task) HasHealthCheckResults() bool {
 // AllTasks lists tasks of all applications.
 //		opts: 		AllTasksOpts request payload
 func (r *marathonClient) AllTasks(opts *AllTasksOpts) (*Tasks, error) {
-	u, err := addOptions(marathonAPITasks, opts)
+	path, err := addOptions(marathonAPITasks, opts)
 	if err != nil {
 		return nil, err
 	}
 
 	tasks := new(Tasks)
-	if err := r.apiGet(u, nil, tasks); err != nil {
+	if err := r.apiGet(path, nil, tasks); err != nil {
 		return nil, err
 	}
 
@@ -107,14 +107,14 @@ func (r *marathonClient) Tasks(id string) (*Tasks, error) {
 //		id:		the id of the application
 //		opts: 		KillApplicationTasksOpts request payload
 func (r *marathonClient) KillApplicationTasks(id string, opts *KillApplicationTasksOpts) (*Tasks, error) {
-	u := fmt.Sprintf("%s/%s/tasks", marathonAPIApps, trimRootPath(id))
-	u, err := addOptions(u, opts)
+	path := fmt.Sprintf("%s/%s/tasks", marathonAPIApps, trimRootPath(id))
+	path, err := addOptions(path, opts)
 	if err != nil {
 		return nil, err
 	}
 
 	tasks := new(Tasks)
-	if err := r.apiDelete(u, nil, tasks); err != nil {
+	if err := r.apiDelete(path, nil, tasks); err != nil {
 		return nil, err
 	}
 
@@ -129,8 +129,8 @@ func (r *marathonClient) KillTask(taskID string, opts *KillTaskOpts) (*Task, err
 	appName = strings.Replace(appName, "_", "/", -1)
 	taskID = strings.Replace(taskID, "/", "_", -1)
 
-	u := fmt.Sprintf("%s/%s/tasks/%s", marathonAPIApps, appName, taskID)
-	u, err := addOptions(u, opts)
+	path := fmt.Sprintf("%s/%s/tasks/%s", marathonAPIApps, appName, taskID)
+	path, err := addOptions(path, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (r *marathonClient) KillTask(taskID string, opts *KillTaskOpts) (*Task, err
 		Task Task `json:"task"`
 	})
 
-	if err := r.apiDelete(u, nil, wrappedTask); err != nil {
+	if err := r.apiDelete(path, nil, wrappedTask); err != nil {
 		return nil, err
 	}
 
@@ -150,8 +150,8 @@ func (r *marathonClient) KillTask(taskID string, opts *KillTaskOpts) (*Task, err
 //	tasks:		the array of task ids
 //	opts:		KillTaskOpts request payload
 func (r *marathonClient) KillTasks(tasks []string, opts *KillTaskOpts) error {
-	u := fmt.Sprintf("%s/delete", marathonAPITasks)
-	u, err := addOptions(u, opts)
+	path := fmt.Sprintf("%s/delete", marathonAPITasks)
+	path, err := addOptions(path, opts)
 	if err != nil {
 		return nil
 	}
@@ -161,7 +161,7 @@ func (r *marathonClient) KillTasks(tasks []string, opts *KillTaskOpts) error {
 	}
 	post.IDs = tasks
 
-	return r.apiPost(u, &post, nil)
+	return r.apiPost(path, &post, nil)
 }
 
 // TaskEndpoints gets the endpoints i.e. HOST_IP:DYNAMIC_PORT for a specific application service


### PR DESCRIPTION
I was manually testing marathon member failover and stumbled over a problem with the current implementation of healthCheckNode. It builds a request like `http://127.0.0.1:57142//ping`. Testing with a Marathon cluster of version 1.3.10 I think this is a real problem.

I checked the test cases and saw there are actually tests. The problem why this is not detected by the tests is that go cleans up such paths by default. See [StackOverflow](http://stackoverflow.com/questions/23285364/does-go-sanitize-urls-for-web-requests) for some explanation. Also due to this sanitisation I was not able to come up with a good regression test :/