### PR TITLE
Add pod support

### DIFF
--- a/client.go
+++ b/client.go
@@ -69,6 +69,40 @@ type Marathon interface {
 	// wait of application
 	WaitOnApplication(name string, timeout time.Duration) error
 
+	// -- PODS ---
+	// whether which version of Marathon supports pods
+	SupportsPods() bool
+
+	// get pod status
+	GetPodStatus(name string) (*PodStatus, error)
+	// get all pod status
+	GetAllPodStatus() ([]*PodStatus, error)
+
+	// get pod
+	GetPod(name string) (*Pod, error)
+	// get all pods
+	GetAllPods() ([]*Pod, error)
+	// create pod
+	CreatePod(pod *Pod) (*Pod, error)
+	// update pod
+	UpdatePod(pod *Pod, force bool) (*Pod, error)
+	// delete pod
+	DeletePod(name string, force bool) (*DeploymentID, error)
+	// wait on pod to deploy
+	WaitOnPod(name string, timeout time.Duration) error
+	// pod is running
+	PodExistsAndRunning(name string) bool
+
+	// get versions of a pod
+	GetVersions(name string) ([]string, error)
+	// geet pod by version
+	GetPodByVersion(name, version string) (*Pod, error)
+
+	// delete instances of a pod
+	DeletePodInstances(name string, instances []string) ([]*PodInstance, error)
+	// delete pod instance
+	DeletePodInstance(name, instance string) (*PodInstance, error)
+
 	// -- TASKS ---
 
 	// get a list of tasks for a specific application
@@ -242,6 +276,10 @@ func (r *marathonClient) Ping() (bool, error) {
 	return true, nil
 }
 
+func (r *marathonClient) apiHead(path string, post, result interface{}) error {
+	return r.apiCall("HEAD", path, post, result)
+}
+
 func (r *marathonClient) apiGet(path string, post, result interface{}) error {
 	return r.apiCall("GET", path, post, result)
 }
@@ -259,6 +297,8 @@ func (r *marathonClient) apiDelete(path string, post, result interface{}) error 
 }
 
 func (r *marathonClient) apiCall(method, path string, body, result interface{}) error {
+	const deploymentHeader = "Marathon-Deployment-Id"
+
 	for {
 		// step: marshall the request to json
 		var requestBody []byte
@@ -277,6 +317,7 @@ func (r *marathonClient) apiCall(method, path string, body, result interface{}) 
 
 		// step: perform the API request
 		response, err := r.client.Do(request)
+
 		if err != nil {
 			r.hosts.markDown(member)
 			// step: attempt the request on another member
@@ -299,9 +340,23 @@ func (r *marathonClient) apiCall(method, path string, body, result interface{}) 
 
 		// step: check for a successfull response
 		if response.StatusCode >= 200 && response.StatusCode <= 299 {
+
 			if result != nil {
-				if err := json.Unmarshal(respBody, result); err != nil {
-					return fmt.Errorf("failed to unmarshal response from Marathon: %s", err)
+				// If we have a deployment ID header and no response body, give them that
+				deploymentID := response.Header.Get(deploymentHeader)
+				if len(respBody) == 0 && deploymentID != "" {
+					d := DeploymentID{
+						DeploymentID: deploymentID,
+					}
+					switch result.(type) {
+					case *DeploymentID:
+						*result.(*DeploymentID) = d
+					}
+
+				} else {
+					if err := json.Unmarshal(respBody, result); err != nil {
+						return fmt.Errorf("failed to unmarshal response from Marathon: %s", err)
+					}
 				}
 			}
 			return nil

--- a/const.go
+++ b/const.go
@@ -24,6 +24,7 @@ const (
 	marathonAPIEventStream  = marathonAPIVersion + "/events"
 	marathonAPISubscription = marathonAPIVersion + "/eventSubscriptions"
 	marathonAPIApps         = marathonAPIVersion + "/apps"
+	marathonAPIPods         = marathonAPIVersion + "/pods"
 	marathonAPITasks        = marathonAPIVersion + "/tasks"
 	marathonAPIDeployments  = marathonAPIVersion + "/deployments"
 	marathonAPIGroups       = marathonAPIVersion + "/groups"

--- a/health.go
+++ b/health.go
@@ -30,6 +30,35 @@ type HealthCheck struct {
 	IgnoreHTTP1xx          *bool    `json:"ignoreHttp1xx,omitempty"`
 }
 
+// HTTPHealthCheck describes an HTTP based health check
+type HTTPHealthCheck struct {
+	Endpoint string `json:"endpoint,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Scheme   string `json:"scheme,omitempty"`
+}
+
+// TCPHealthCheck describes a TCP based health check
+type TCPHealthCheck struct {
+	Endpoint string `json:"endpoint,omitempty"`
+}
+
+// CommandHealthCheck describes a shell-based health check
+type CommandHealthCheck struct {
+	Command PodCommand `json:"command,omitempty"`
+}
+
+// PodHealthCheck describes how to determine a pod's health
+type PodHealthCheck struct {
+	HTTP                   *HTTPHealthCheck    `json:"http,omitempty"`
+	TCP                    *TCPHealthCheck     `json:"tcp,omitempty"`
+	Exec                   *CommandHealthCheck `json:"exec,omitempty"`
+	GracePeriodSeconds     int                 `json:"gracePeriodSeconds,omitempty"`
+	IntervalSeconds        int                 `json:"intervalSeconds,omitempty"`
+	MaxConsecutiveFailures int                 `json:"maxConsecutiveFailures,omitempty"`
+	TimeoutSeconds         int                 `json:"timeoutSeconds,omitempty"`
+	DelaySeconds           int                 `json:"delaySeconds,omitempty"`
+}
+
 // SetCommand sets the given command on the health check.
 func (h HealthCheck) SetCommand(c Command) HealthCheck {
 	h.Command = &c

--- a/network.go
+++ b/network.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+// PodNetwork contains network descriptors for a pod
+type PodNetwork struct {
+	Name   string            `json:"name,omitempty"`
+	Mode   string            `json:"mode,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// PodEndpoint describes an endpoint for a pod's container
+type PodEndpoint struct {
+	Name          string            `json:"name,omitempty"`
+	ContainerPort int               `json:"containerPort,omitempty"`
+	HostPort      int               `json:"hostPort,omitempty"`
+	Protocol      []string          `json:"protocol,omitempty"`
+	Labels        map[string]string `json:"labels,omitempty"`
+}
+
+// NewPodNetwork creates an empty PodNetwork
+func NewPodNetwork(name string) *PodNetwork {
+	return &PodNetwork{
+		Name:   name,
+		Labels: map[string]string{},
+	}
+}
+
+// NewPodEndpoint creates an empty PodEndpoint
+func NewPodEndpoint() *PodEndpoint {
+	return &PodEndpoint{
+		Protocol: []string{},
+		Labels:   map[string]string{},
+	}
+}
+
+// NewContainerPodNetwork creates a PodNetwork for a container
+func NewContainerPodNetwork(name string) *PodNetwork {
+	pn := NewPodNetwork(name)
+	return pn.SetMode("container")
+}
+
+// SetName sets the name of a PodNetwork
+func (n *PodNetwork) SetName(name string) *PodNetwork {
+	n.Name = name
+	return n
+}
+
+// SetMode sets the mode of a PodNetwork
+func (n *PodNetwork) SetMode(mode string) *PodNetwork {
+	n.Mode = mode
+	return n
+}
+
+// Label sets a label of a PodNetwork
+func (n *PodNetwork) Label(key, value string) *PodNetwork {
+	n.Labels[key] = value
+	return n
+}
+
+// SetName sets the name for a PodEndpoint
+func (e *PodEndpoint) SetName(name string) *PodEndpoint {
+	e.Name = name
+	return e
+}
+
+// SetContainerPort sets the container port for a PodEndpoint
+func (e *PodEndpoint) SetContainerPort(port int) *PodEndpoint {
+	e.ContainerPort = port
+	return e
+}
+
+// SetHostPort sets the host port for a PodEndpoint
+func (e *PodEndpoint) SetHostPort(port int) *PodEndpoint {
+	e.HostPort = port
+	return e
+}
+
+// AddProtocol appends a protocol for a PodEndpoint
+func (e *PodEndpoint) AddProtocol(protocol string) *PodEndpoint {
+	e.Protocol = append(e.Protocol, protocol)
+	return e
+}
+
+// Label sets a label for a PodEndpoint
+func (e *PodEndpoint) Label(key, value string) *PodEndpoint {
+	e.Labels[key] = value
+	return e
+}

--- a/pod.go
+++ b/pod.go
@@ -1,0 +1,310 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Pod is the definition for an pod in marathon
+type Pod struct {
+	ID                string                  `json:"id,omitempty"`
+	Labels            map[string]string       `json:"labels,omitempty"`
+	Version           string                  `json:"version,omitempty"`
+	User              string                  `json:"user,omitempty"`
+	Environment       map[string]interface{}  `json:"environment,omitempty"`
+	Containers        []*PodContainer         `json:"containers,omitempty"`
+	Secrets           map[string]SecretSource `json:"secrets,omitempty"`
+	Volumes           []*PodVolume            `json:"volumes,omitempty"`
+	Networks          []*PodNetwork           `json:"networks,omitempty"`
+	Scaling           *PodScalingPolicy       `json:"scaling,omitempty"`
+	Scheduling        *PodSchedulingPolicy    `json:"scheduling,omitempty"`
+	ExecutorResources *ExecutorResources      `json:"executorResources,omitempty"`
+}
+
+// PodScalingPolicy is the scaling policy of the pod
+type PodScalingPolicy struct {
+	Kind         string `json:"kind"`
+	Instances    int    `json:"instances"`
+	MaxInstances int    `json:"maxInstances,omitempty"`
+}
+
+// NewPod create an empty pod
+func NewPod() *Pod {
+	return &Pod{
+		Labels:      map[string]string{},
+		Environment: map[string]interface{}{},
+		Containers:  []*PodContainer{},
+		Secrets:     map[string]SecretSource{},
+		Volumes:     []*PodVolume{},
+		Networks:    []*PodNetwork{},
+	}
+}
+
+// String marshals the pod as an indented string
+func (p *Pod) String() string {
+	s, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Sprintf(`{"error": "error decoding type into json: %s"}`, err)
+	}
+
+	return string(s)
+}
+
+// Name sets the name / ID of the pod i.e. the identifier for this pod
+func (p *Pod) Name(id string) *Pod {
+	p.ID = validateID(id)
+	return p
+}
+
+// SetUser sets the user to run the pod as
+func (p *Pod) SetUser(user string) *Pod {
+	p.User = user
+	return p
+}
+
+// EmptyLabels empties the labels in a pod
+func (p *Pod) EmptyLabels() *Pod {
+	p.Labels = make(map[string]string)
+	return p
+}
+
+// AddLabel adds a label to a pod
+func (p *Pod) AddLabel(key, value string) *Pod {
+	p.Labels[key] = value
+	return p
+}
+
+// SetLabels sets the labels for a pod
+func (p *Pod) SetLabels(labels map[string]string) *Pod {
+	p.Labels = labels
+	return p
+}
+
+// EmptyEnvironment empties the environment variables for a pod
+func (p *Pod) EmptyEnvironment() *Pod {
+	p.Environment = make(map[string]interface{})
+	return p
+}
+
+// AddEnvironment adds an environment variable to a pod
+func (p *Pod) AddEnvironment(name, value string) *Pod {
+	p.Environment[name] = value
+	return p
+}
+
+// ExtendEnvironment extends the environment with the new environment variables
+func (p *Pod) ExtendEnvironment(env map[string]string) *Pod {
+	for k, v := range env {
+		p.AddEnvironment(k, v)
+	}
+	return p
+}
+
+// GetEnvironmentVariable gets the string contained in an environment variable
+func (p *Pod) GetEnvironmentVariable(name string) (string, error) {
+	str := ""
+	var err error
+
+	if val, ok := p.Environment[name]; ok {
+		switch val.(type) {
+		case string:
+			str = val.(string)
+			err = nil
+		case EnvironmentSecret:
+			err = fmt.Errorf("environment variable refers to a secret")
+		default:
+			err = fmt.Errorf("environment variable refers to unknown type")
+		}
+	} else {
+		err = fmt.Errorf("environment variable not found")
+	}
+	return str, err
+}
+
+// AddEnvironmentSecret adds a secret to a pod
+func (p *Pod) AddEnvironmentSecret(name, secretName string) *Pod {
+	p.Environment[name] = EnvironmentSecret{
+		Secret: secretName,
+	}
+	return p
+}
+
+// AddContainer adds a container to a pod
+func (p *Pod) AddContainer(container *PodContainer) *Pod {
+	p.Containers = append(p.Containers, container)
+	return p
+}
+
+// EmptySecrets empties the secret sources in a pod
+func (p *Pod) EmptySecrets() *Pod {
+	p.Secrets = make(map[string]SecretSource)
+	return p
+}
+
+// GetSecretSource gets the source of the named secret
+func (p *Pod) GetSecretSource(name string) (string, error) {
+	if val, ok := p.Secrets[name]; ok {
+		return val.Source, nil
+	}
+	return "", fmt.Errorf("secret does not exist")
+}
+
+// AddSecret adds a secret source to a pod
+func (p *Pod) AddSecret(name, value string) *Pod {
+	p.Secrets[name] = SecretSource{
+		Source: value,
+	}
+	return p
+}
+
+// AddVolume adds a volume to a pod
+func (p *Pod) AddVolume(vol *PodVolume) *Pod {
+	p.Volumes = append(p.Volumes, vol)
+	return p
+}
+
+// AddNetwork adds a PodNetwork to a pod
+func (p *Pod) AddNetwork(net *PodNetwork) *Pod {
+	p.Networks = append(p.Networks, net)
+	return p
+}
+
+// Count sets the count of the pod
+func (p *Pod) Count(count int) *Pod {
+	p.Scaling = &PodScalingPolicy{
+		Kind:      "fixed",
+		Instances: count,
+	}
+	return p
+}
+
+// SetPodSchedulingPolicy sets the PodSchedulingPolicy of a pod
+func (p *Pod) SetPodSchedulingPolicy(policy *PodSchedulingPolicy) *Pod {
+	p.Scheduling = policy
+	return p
+}
+
+// SetExecutorResources sets the resources for the pod executor
+func (p *Pod) SetExecutorResources(resources *ExecutorResources) *Pod {
+	p.ExecutorResources = resources
+	return p
+}
+
+// SupportsPods determines if this version of marathon supports pods
+// If HEAD returns 200 it does
+func (r *marathonClient) SupportsPods() bool {
+	if err := r.apiHead(marathonAPIPods, nil, nil); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// GetPod gets a pod from marathon
+// 		name: 		the id used to identify the pod
+func (r *marathonClient) GetPod(name string) (*Pod, error) {
+	uri := buildPodURI(name)
+	result := new(Pod)
+	if err := r.apiGet(uri, nil, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetAllPods gets all pods from marathon
+func (r *marathonClient) GetAllPods() ([]*Pod, error) {
+	var result []*Pod
+	if err := r.apiGet(marathonAPIPods, nil, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// CreatePod creates a new pod in Marathon
+// 		pod:		the structure holding the pod configuration
+func (r *marathonClient) CreatePod(pod *Pod) (*Pod, error) {
+	result := new(Pod)
+	if err := r.apiPost(marathonAPIPods, &pod, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// DeletePod deletes a pod from marathon
+// 		name: 		the id used to identify the pod
+// 		force: 		whether
+func (r *marathonClient) DeletePod(name string, force bool) (*DeploymentID, error) {
+	uri := fmt.Sprintf("%s?force=%v", buildPodURI(name), force)
+	// step: check of the pod already exists
+	deployID := new(DeploymentID)
+	if err := r.apiDelete(uri, nil, deployID); err != nil {
+		return nil, err
+	}
+
+	return deployID, nil
+}
+
+// CreatePod creates a new pod in Marathon
+// 		pod:		the structure holding the pod configuration
+func (r *marathonClient) UpdatePod(pod *Pod, force bool) (*Pod, error) {
+	uri := fmt.Sprintf("%s?force=%v", buildPodURI(pod.ID), force)
+	result := new(Pod)
+	// step: check of the pod already exists
+	if err := r.apiPut(uri, pod, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetVersions gets the versions of a pod
+// 		name:		the id of the pod
+func (r *marathonClient) GetVersions(name string) ([]string, error) {
+	uri := buildPodVersionURI(name)
+	var result []string
+	if err := r.apiGet(uri, nil, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetPodByVersion gets a pod by a version
+// 		name:		the id of the pod
+// 		version:	the version of the pod
+func (r *marathonClient) GetPodByVersion(name, version string) (*Pod, error) {
+	uri := fmt.Sprintf("%s/%s", buildPodVersionURI(name), version)
+	result := new(Pod)
+	if err := r.apiGet(uri, nil, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func buildPodVersionURI(name string) string {
+	return fmt.Sprintf("%s/%s::versions", marathonAPIPods, trimRootPath(name))
+}
+
+func buildPodURI(path string) string {
+	return fmt.Sprintf("%s/%s", marathonAPIPods, trimRootPath(path))
+}

--- a/pod_container.go
+++ b/pod_container.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+// PodContainer describes a container in a pod
+type PodContainer struct {
+	Name         string                 `json:"name,omitempty"`
+	Exec         *PodExec               `json:"exec,omitempty"`
+	Resources    *Resources             `json:"resources,omitempty"`
+	Endpoints    []*PodEndpoint         `json:"endpoints,omitempty"`
+	Image        *PodContainerImage     `json:"image,omitempty"`
+	Environment  map[string]interface{} `json:"environment,omitempty"`
+	User         string                 `json:"user,omitempty"`
+	HealthCheck  *PodHealthCheck        `json:"healthCheck,omitempty"`
+	VolumeMounts []*PodVolumeMount      `json:"volumeMounts,omitempty"`
+	Artifacts    []*PodArtifact         `json:"artifacts,omitempty"`
+	Labels       map[string]string      `json:"labels,omitempty"`
+	Lifecycle    PodLifecycle           `json:"lifecycle,omitempty"`
+}
+
+// PodLifecycle describes the lifecycle of a pod
+type PodLifecycle struct {
+	KillGracePeriodSeconds float64 `json:"killGracePeriodSeconds,omitempty"`
+}
+
+// PodCommand is the command to run as the entrypoint of the container
+type PodCommand struct {
+	Shell string `json:"shell,omitempty"`
+}
+
+// PodExec contains the PodCommand
+type PodExec struct {
+	Command PodCommand `json:"command,omitempty"`
+}
+
+// PodArtifact describes how to obtain a generic artifact for a pod
+type PodArtifact struct {
+	URI        string `json:"uri,omitempty"`
+	Extract    bool   `json:"extract,omitempty"`
+	Executable bool   `json:"executable,omitempty"`
+	Cache      bool   `json:"cache,omitempty"`
+	DestPath   string `json:"destPath,omitempty"`
+}
+
+// NewPodContainer creates an empty PodContainer
+func NewPodContainer() *PodContainer {
+	return &PodContainer{
+		Endpoints:    []*PodEndpoint{},
+		Environment:  map[string]interface{}{},
+		VolumeMounts: []*PodVolumeMount{},
+		Artifacts:    []*PodArtifact{},
+		Labels:       map[string]string{},
+		Resources:    NewResources(),
+	}
+}
+
+// SetName sets the name of a pod container
+func (p *PodContainer) SetName(name string) *PodContainer {
+	p.Name = name
+	return p
+}
+
+// SetCommand sets the shell command of a pod container
+func (p *PodContainer) SetCommand(name string) *PodContainer {
+	p.Exec = &PodExec{
+		Command: PodCommand{
+			Shell: name,
+		},
+	}
+	return p
+}
+
+// CPUs sets the CPUs of a pod container
+func (p *PodContainer) CPUs(cpu float64) *PodContainer {
+	p.Resources.Cpus = cpu
+	return p
+}
+
+// Memory sets the memory of a pod container
+func (p *PodContainer) Memory(memory float64) *PodContainer {
+	p.Resources.Mem = memory
+	return p
+}
+
+// Storage sets the storage capacity of a pod container
+func (p *PodContainer) Storage(disk float64) *PodContainer {
+	p.Resources.Disk = disk
+	return p
+}
+
+// GPUs sets the GPU requirements of a pod container
+func (p *PodContainer) GPUs(gpu int32) *PodContainer {
+	p.Resources.Gpus = gpu
+	return p
+}
+
+// AddEndpoint appends an endpoint for a pod container
+func (p *PodContainer) AddEndpoint(endpoint *PodEndpoint) *PodContainer {
+	p.Endpoints = append(p.Endpoints, endpoint)
+	return p
+}
+
+// SetImage sets the image of a pod container
+func (p *PodContainer) SetImage(image *PodContainerImage) *PodContainer {
+	p.Image = image
+	return p
+}
+
+// AddEnvironment adds an environment variable for a pod container
+func (p *PodContainer) AddEnvironment(name, value string) *PodContainer {
+	p.Environment[name] = value
+	return p
+}
+
+// ExtendEnvironment extends the environment for a pod container
+func (p *PodContainer) ExtendEnvironment(env map[string]string) *PodContainer {
+	for k, v := range env {
+		p.AddEnvironment(k, v)
+	}
+	return p
+}
+
+// AddEnvironmentSecret adds a secret to the environment for a pod container
+func (p *PodContainer) AddEnvironmentSecret(name, secretName string) *PodContainer {
+	p.Environment[name] = EnvironmentSecret{
+		Secret: secretName,
+	}
+	return p
+}
+
+// SetUser sets the user to run the pod as
+func (p *PodContainer) SetUser(user string) *PodContainer {
+	p.User = user
+	return p
+}
+
+// SetHealthCheck sets the health check of a pod container
+func (p *PodContainer) SetHealthCheck(healthcheck *PodHealthCheck) *PodContainer {
+	p.HealthCheck = healthcheck
+	return p
+}
+
+// AddVolumeMount appends a volume mount to a pod container
+func (p *PodContainer) AddVolumeMount(mount *PodVolumeMount) *PodContainer {
+	p.VolumeMounts = append(p.VolumeMounts, mount)
+	return p
+}
+
+// AddArtifact appends an artifact to a pod container
+func (p *PodContainer) AddArtifact(artifact *PodArtifact) *PodContainer {
+	p.Artifacts = append(p.Artifacts, artifact)
+	return p
+}
+
+// AddLabel adds a label to a pod container
+func (p *PodContainer) AddLabel(key, value string) *PodContainer {
+	p.Labels[key] = value
+	return p
+}
+
+// SetLifecycle sets the lifecycle of a pod container
+func (p *PodContainer) SetLifecycle(lifecycle PodLifecycle) *PodContainer {
+	p.Lifecycle = lifecycle
+	return p
+}

--- a/pod_container_image.go
+++ b/pod_container_image.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+// ImageType represents the image format type
+type ImageType string
+
+const (
+	// ImageTypeDocker is the docker format
+	ImageTypeDocker ImageType = "DOCKER"
+
+	// ImageTypeAppC is the appc format
+	ImageTypeAppC ImageType = "APPC"
+)
+
+// PodContainerImage describes how to retrieve the container image
+type PodContainerImage struct {
+	Kind      ImageType `json:"kind,omitempty"`
+	ID        string    `json:"id,omitempty"`
+	ForcePull bool      `json:"forcePull,omitempty"`
+}
+
+// NewPodContainerImage creates an empty PodContainerImage
+func NewPodContainerImage() *PodContainerImage {
+	return &PodContainerImage{}
+}
+
+// SetKind sets the Kind of the image
+func (i *PodContainerImage) SetKind(typ ImageType) *PodContainerImage {
+	i.Kind = typ
+	return i
+}
+
+// SetID sets the ID of the image
+func (i *PodContainerImage) SetID(id string) *PodContainerImage {
+	i.ID = id
+	return i
+}
+
+// NewDockerPodContainerImage creates a docker PodContainerImage
+func NewDockerPodContainerImage() *PodContainerImage {
+	return NewPodContainerImage().SetKind(ImageTypeDocker)
+}

--- a/pod_instance.go
+++ b/pod_instance.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// PodInstance is the representation of an instance as returned by deleting an instance
+type PodInstance struct {
+	InstanceID          PodInstanceID              `json:"instanceId"`
+	AgentInfo           PodAgentInfo               `json:"agentInfo"`
+	TasksMap            map[string]PodTask         `json:"tasksMap"`
+	RunSpecVersion      time.Time                  `json:"runSpecVersion"`
+	State               PodInstanceStateHistory    `json:"state"`
+	UnreachableStrategy EnabledUnreachableStrategy `json:"unreachableStrategy"`
+}
+
+// PodInstanceStateHistory is the pod instance's state
+type PodInstanceStateHistory struct {
+	Condition   PodTaskCondition `json:"condition"`
+	Since       time.Time        `json:"since"`
+	ActiveSince time.Time        `json:"activeSince"`
+}
+
+// PodInstanceID contains the instance ID
+type PodInstanceID struct {
+	ID string `json:"idString"`
+}
+
+// PodAgentInfo contains info about the agent the instance is running on
+type PodAgentInfo struct {
+	Host       string   `json:"host"`
+	AgentID    string   `json:"agentId"`
+	Attributes []string `json:"attributes"`
+}
+
+// PodTask contains the info about the specific task within the instance
+type PodTask struct {
+	TaskID         string        `json:"taskId"`
+	RunSpecVersion time.Time     `json:"runSpecVersion"`
+	Status         PodTaskStatus `json:"status"`
+}
+
+// PodTaskStatus is the current status of the task
+type PodTaskStatus struct {
+	StagedAt    time.Time        `json:"stagedAt"`
+	StartedAt   time.Time        `json:"startedAt"`
+	MesosStatus string           `json:"mesosStatus"`
+	Condition   PodTaskCondition `json:"condition"`
+	NetworkInfo PodNetworkInfo   `json:"networkInfo"`
+}
+
+// PodTaskCondition contains a string representation of the condition
+type PodTaskCondition struct {
+	Str string `json:"str"`
+}
+
+// PodNetworkInfo contains the network info for a task
+type PodNetworkInfo struct {
+	HostName    string      `json:"hostName"`
+	HostPorts   []int       `json:"hostPorts"`
+	IPAddresses []IPAddress `json:"ipAddresses"`
+}
+
+// String marshals the pod as an indented string
+func (p *PodInstance) String() string {
+	s, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Sprintf(`{"error": "error decoding type into json: %s"}`, err)
+	}
+
+	return string(s)
+}
+
+// DeletePodInstances deletes all instances of the named pod
+func (r *marathonClient) DeletePodInstances(name string, instances []string) ([]*PodInstance, error) {
+	uri := buildPodInstancesURI(name)
+	var result []*PodInstance
+	if err := r.apiDelete(uri, instances, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// DeletePodInstance deletes a specific instance of a pod
+func (r *marathonClient) DeletePodInstance(name, instance string) (*PodInstance, error) {
+	uri := fmt.Sprintf("%s/%s", buildPodInstancesURI(name), instance)
+	result := new(PodInstance)
+	if err := r.apiDelete(uri, nil, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func buildPodInstancesURI(path string) string {
+	return fmt.Sprintf("%s/%s::instances", marathonAPIPods, trimRootPath(path))
+}

--- a/pod_instance_status.go
+++ b/pod_instance_status.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+// PodInstanceState is the state of a specific pod instance
+type PodInstanceState string
+
+const (
+	// PodInstanceStatePending is when an instance is pending scheduling
+	PodInstanceStatePending PodInstanceState = "PENDING"
+
+	// PodInstanceStateStaging is when an instance is staged to be scheduled
+	PodInstanceStateStaging PodInstanceState = "STAGING"
+
+	// PodInstanceStateStable is when an instance is stably running
+	PodInstanceStateStable PodInstanceState = "STABLE"
+
+	// PodInstanceStateDegraded is when an instance is degraded status
+	PodInstanceStateDegraded PodInstanceState = "DEGRADED"
+
+	// PodInstanceStateTerminal is when an instance is terminal
+	PodInstanceStateTerminal PodInstanceState = "TERMINAL"
+)
+
+// PodInstanceStatus is the status of a pod instance
+type PodInstanceStatus struct {
+	AgentHostname string              `json:"agentHostname,omitempty"`
+	Conditions    []*StatusCondition  `json:"conditions,omitempty"`
+	Containers    []*ContainerStatus  `json:"containers,omitempty"`
+	ID            string              `json:"id,omitempty"`
+	LastChanged   string              `json:"lastChanged,omitempty"`
+	LastUpdated   string              `json:"lastUpdated,omitempty"`
+	Message       string              `json:"message,omitempty"`
+	Networks      []*PodNetworkStatus `json:"networks,omitempty"`
+	Resources     *Resources          `json:"resources,omitempty"`
+	SpecReference string              `json:"specReference,omitempty"`
+	Status        PodInstanceState    `json:"status,omitempty"`
+	StatusSince   string              `json:"statusSince,omitempty"`
+}
+
+// PodNetworkStatus is the networks attached to a pod instance
+type PodNetworkStatus struct {
+	Addresses []string `json:"addresses,omitempty"`
+	Name      string   `json:"name,omitempty"`
+}
+
+// StatusCondition describes info about a status change
+type StatusCondition struct {
+	Name        string `json:"name,omitempty"`
+	Value       string `json:"value,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+	LastChanged string `json:"lastChanged,omitempty"`
+	LastUpdated string `json:"lastUpdated,omitempty"`
+}
+
+// ContainerStatus is all of the status for a container
+type ContainerStatus struct {
+	Conditions  []*StatusCondition         `json:"conditions,omitempty"`
+	ContainerID string                     `json:"containerId,omitempty"`
+	Endpoints   []*PodEndpoint             `json:"endpoints,omitempty"`
+	LastChanged string                     `json:"lastChanged,omitempty"`
+	LastUpdated string                     `json:"lastUpdated,omitempty"`
+	Message     string                     `json:"message,omitempty"`
+	Name        string                     `json:"name,omitempty"`
+	Resources   *Resources                 `json:"resources,omitempty"`
+	Status      string                     `json:"status,omitempty"`
+	StatusSince string                     `json:"statusSince,omitempty"`
+	Termination *ContainerTerminationState `json:"termination,omitempty"`
+}
+
+// ContainerTerminationState describes why a container terminated
+type ContainerTerminationState struct {
+	ExitCode int    `json:"exitCode,omitempty"`
+	Message  string `json:"message,omitempty"`
+}

--- a/pod_instance_test.go
+++ b/pod_instance_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const fakePodInstanceName = "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003"
+
+func TestDeletePodInstance(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	podInstance, err := endpoint.Client.DeletePodInstance(fakePodName, fakePodInstanceName)
+	assert.NoError(t, err)
+	assert.Equal(t, podInstance.InstanceID.ID, fakePodInstanceName)
+}
+
+func TestDeletePodInstances(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	instances := []string{fakePodInstanceName}
+	podInstances, err := endpoint.Client.DeletePodInstances(fakePodName, instances)
+	assert.NoError(t, err)
+	assert.Equal(t, podInstances[0].InstanceID.ID, fakePodInstanceName)
+}

--- a/pod_scheduling.go
+++ b/pod_scheduling.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+// PodBackoff describes the backoff for re-run attempts of a pod
+type PodBackoff struct {
+	Backoff        int     `json:"backoff"`
+	BackoffFactor  float64 `json:"backoffFactor"`
+	MaxLaunchDelay int     `json:"maxLaunchDelay"`
+}
+
+// PodUpgrade describes the policy for upgrading a pod in-place
+type PodUpgrade struct {
+	MinimumHealthCapacity int `json:"minimumHealthCapacity"`
+	MaximumOverCapacity   int `json:"maximumOverCapacity"`
+}
+
+// PodPlacement supports constraining which hosts a pod is placed on
+type PodPlacement struct {
+	Constraints           *[][]string `json:"constraints"`
+	AcceptedResourceRoles []string    `json:"acceptedResourceRoles,omitempty"`
+}
+
+// PodSchedulingPolicy is the overarching pod scheduling policy
+type PodSchedulingPolicy struct {
+	Backoff   *PodBackoff   `json:"backoff,omitempty"`
+	Upgrade   *PodUpgrade   `json:"upgrade,omitempty"`
+	Placement *PodPlacement `json:"placement,omitempty"`
+}
+
+// NewPodPlacement creates an empty PodPlacement
+func NewPodPlacement() *PodPlacement {
+	return &PodPlacement{
+		Constraints:           &[][]string{},
+		AcceptedResourceRoles: []string{},
+	}
+}
+
+// AddConstraint adds a new constraint
+//		constraints:	the constraint definition, one constraint per array element
+func (r *PodPlacement) AddConstraint(constraints ...string) *PodPlacement {
+	c := *r.Constraints
+	c = append(c, constraints)
+	r.Constraints = &c
+
+	return r
+}
+
+// NewPodSchedulingPolicy creates an empty PodSchedulingPolicy
+func NewPodSchedulingPolicy() *PodSchedulingPolicy {
+	return &PodSchedulingPolicy{
+		Placement: NewPodPlacement(),
+	}
+}

--- a/pod_status.go
+++ b/pod_status.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// PodState defines the state of a pod
+type PodState string
+
+const (
+	// PodStateDegraded is a degraded pod
+	PodStateDegraded PodState = "DEGRADED"
+
+	// PodStateStable is a stable pod
+	PodStateStable PodState = "STABLE"
+
+	// PodStateTerminal is a terminal pod
+	PodStateTerminal PodState = "TERMINAL"
+)
+
+// PodStatus describes the pod status
+type PodStatus struct {
+	ID                 string                   `json:"id,omitempty"`
+	Spec               *Pod                     `json:"spec,omitempty"`
+	Status             PodState                 `json:"status,omitempty"`
+	StatusSince        string                   `json:"statusSince,omitempty"`
+	Message            string                   `json:"message,omitempty"`
+	Instances          []*PodInstanceStatus     `json:"instances,omitempty"`
+	TerminationHistory []*PodTerminationHistory `json:"terminationHistory,omitempty"`
+	LastUpdated        string                   `json:"lastUpdated,omitempty"`
+	LastChanged        string                   `json:"lastChanged,omitempty"`
+}
+
+// PodTerminationHistory is the termination history of the pod
+type PodTerminationHistory struct {
+	InstanceID   string                         `json:"instanceId,omitempty"`
+	StartedAt    string                         `json:"startedAt,omitempty"`
+	TerminatedAt string                         `json:"terminatedAt,omitempty"`
+	Message      string                         `json:"message,omitempty"`
+	Containers   []*ContainerTerminationHistory `json:"containers,omitempty"`
+}
+
+// ContainerTerminationHistory is the termination history of a container in a pod
+type ContainerTerminationHistory struct {
+	ContainerID    string                     `json:"containerId,omitempty"`
+	LastKnownState string                     `json:"lastKnownState,omitempty"`
+	Termination    *ContainerTerminationState `json:"termination,omitempty"`
+}
+
+// String marshals the pod as an indented string
+func (p *PodStatus) String() string {
+	s, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Sprintf(`{"error": "error decoding type into json: %s"}`, err)
+	}
+
+	return string(s)
+}
+
+// GetPodStatus retrieves the pod configuration from marathon
+// 		name: 		the id used to identify the pod
+func (r *marathonClient) GetPodStatus(name string) (*PodStatus, error) {
+	var podStatus PodStatus
+
+	if err := r.apiGet(buildPodStatusURI(name), nil, &podStatus); err != nil {
+		return nil, err
+	}
+
+	return &podStatus, nil
+}
+
+// GetAllPodStatus retrieves all pod configuration from marathon
+func (r *marathonClient) GetAllPodStatus() ([]*PodStatus, error) {
+	var podStatuses []*PodStatus
+
+	if err := r.apiGet(buildPodStatusURI(""), nil, &podStatuses); err != nil {
+		return nil, err
+	}
+
+	return podStatuses, nil
+}
+
+// WaitOnPod waits for a pod to be deployed
+//		name:		the id of the pod
+//		timeout:	a duration of time to wait for an pod to deploy
+func (r *marathonClient) WaitOnPod(name string, timeout time.Duration) error {
+	if r.PodExistsAndRunning(name) {
+		return nil
+	}
+
+	timeoutTimer := time.After(timeout)
+	ticker := time.NewTicker(r.config.PollingWaitTime)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeoutTimer:
+			return ErrTimeoutError
+		case <-ticker.C:
+			if r.PodExistsAndRunning(name) {
+				return nil
+			}
+		}
+	}
+}
+
+// PodExistsAndRunning returns whether the pod is stably running
+func (r *marathonClient) PodExistsAndRunning(name string) bool {
+	podStatus, err := r.GetPodStatus(name)
+	if apiErr, ok := err.(*APIError); ok && apiErr.ErrCode == ErrCodeNotFound {
+		return false
+	}
+	if err == nil && podStatus.Status == PodStateStable {
+		return true
+	}
+	return false
+}
+
+func buildPodStatusURI(path string) string {
+	return fmt.Sprintf("%s/%s::status", marathonAPIPods, trimRootPath(path))
+}

--- a/pod_status_test.go
+++ b/pod_status_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestGetPodStatus(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	podStatus, err := endpoint.Client.GetPodStatus(fakePodName)
+	assert.NoError(t, err)
+	assert.NotNil(t, podStatus)
+	assert.Equal(t, podStatus.Spec.ID, fakePodName)
+}
+
+func TestGetAllPodStatus(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	podStatuses, err := endpoint.Client.GetAllPodStatus()
+	assert.NoError(t, err)
+	assert.Equal(t, podStatuses[0].Spec.ID, fakePodName)
+}
+
+func TestWaitOnPod(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	err := endpoint.Client.WaitOnPod(fakePodName, 1*time.Microsecond)
+	assert.NoError(t, err)
+}
+
+func TestPodExistsAndRunning(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	exists := endpoint.Client.PodExistsAndRunning(fakePodName)
+	assert.True(t, exists)
+}

--- a/pod_test.go
+++ b/pod_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const key = "testKey"
+const val = "testValue"
+
+const fakePodName = "/fake-pod"
+
+func TestPodLabels(t *testing.T) {
+	pod := NewPod()
+	pod.AddLabel(key, val)
+	assert.Equal(t, pod.Labels[key], val)
+
+	pod.EmptyLabels()
+	assert.Equal(t, len(pod.Labels), 0)
+}
+
+func TestPodEnvironmentVars(t *testing.T) {
+	pod := NewPod()
+	pod.AddEnvironment(key, val)
+
+	newVal, err := pod.GetEnvironmentVariable(key)
+	assert.Equal(t, newVal, val)
+	assert.Equal(t, err, nil)
+
+	badVal, err := pod.GetEnvironmentVariable("fakeKey")
+	assert.Equal(t, badVal, "")
+	assert.NotNil(t, err)
+
+	pod.EmptyEnvironment()
+	assert.Equal(t, len(pod.Environment), 0)
+}
+
+func TestSecrets(t *testing.T) {
+	pod := NewPod()
+	pod.AddSecret(key, val)
+
+	newVal, err := pod.GetSecretSource(key)
+	assert.Equal(t, newVal, val)
+	assert.Equal(t, err, nil)
+
+	badVal, err := pod.GetSecretSource("fakeKey")
+	assert.Equal(t, badVal, "")
+	assert.NotNil(t, err)
+
+	pod.EmptySecrets()
+	assert.Equal(t, len(pod.Environment), 0)
+}
+
+func TestSupportsPod(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	supports := endpoint.Client.SupportsPods()
+	assert.Equal(t, supports, true)
+}
+
+func TestGetPod(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	pod, err := endpoint.Client.GetPod(fakePodName)
+	assert.NoError(t, err)
+	assert.NotNil(t, pod)
+	assert.Equal(t, pod.ID, fakePodName)
+}
+
+func TestGetAllPods(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	pods, err := endpoint.Client.GetAllPods()
+	assert.NoError(t, err)
+	assert.Equal(t, pods[0].ID, fakePodName)
+}
+
+func TestCreatePod(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	pod := NewPod().Name(fakePodName)
+	pod, err := endpoint.Client.CreatePod(pod)
+	assert.NoError(t, err)
+	assert.NotNil(t, pod)
+	assert.Equal(t, pod.ID, fakePodName)
+}
+
+func TestUpdatePod(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	pod := NewPod().Name(fakePodName)
+	pod, err := endpoint.Client.CreatePod(pod)
+	pod, err = endpoint.Client.UpdatePod(pod, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, pod)
+	assert.Equal(t, pod.ID, fakePodName)
+	assert.Equal(t, pod.Scaling.Instances, 2)
+}
+
+func TestDeletePod(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	id, err := endpoint.Client.DeletePod(fakePodName, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, id)
+	assert.Equal(t, id.DeploymentID, "c0e7434c-df47-4d23-99f1-78bd78662231")
+}
+
+func TestVersions(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	versions, err := endpoint.Client.GetVersions(fakePodName)
+	assert.NoError(t, err)
+	assert.Equal(t, versions[0], "2014-08-18T22:36:41.451Z")
+}
+
+func TestGetPodByVersion(t *testing.T) {
+	endpoint := newFakeMarathonEndpoint(t, nil)
+	defer endpoint.Close()
+
+	pod, err := endpoint.Client.GetPodByVersion(fakePodName, "2014-08-18T22:36:41.451Z")
+	assert.NoError(t, err)
+	assert.Equal(t, pod.ID, fakePodName)
+}
+

--- a/resources.go
+++ b/resources.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+// ExecutorResources are the resources supported by an executor (a task running a pod)
+type ExecutorResources struct {
+	Cpus float64 `json:"cpus,omitempty"`
+	Mem  float64 `json:"mem,omitempty"`
+	Disk float64 `json:"disk,omitempty"`
+}
+
+// Resources are the full set of resources for a task
+type Resources struct {
+	Cpus float64 `json:"cpus"`
+	Mem  float64 `json:"mem"`
+	Disk float64 `json:"disk,omitempty"`
+	Gpus int32   `json:"gpus,omitempty"`
+}
+
+// NewResources creates an empty Resources
+func NewResources() *Resources {
+	return &Resources{}
+}

--- a/secret.go
+++ b/secret.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+// SecretSource describes the source of a secret
+type SecretSource struct {
+	Source string `json:"source"`
+}
+
+// EnvironmentSecret contains the secret name to retrieve
+type EnvironmentSecret struct {
+	Secret string `json:"secret"`
+}

--- a/testing_utils_test.go
+++ b/testing_utils_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -49,8 +50,9 @@ var (
 )
 
 type indexedResponse struct {
-	Index   int    `yaml:"index,omitempty"`
-	Content string `yaml:"content,omitempty"`
+	Index   int               `yaml:"index,omitempty"`
+	Content string            `yaml:"content,omitempty"`
+	Headers map[string]string `yaml:"headers,omitempty"`
 }
 
 type responseIndices struct {
@@ -74,6 +76,8 @@ type restMethod struct {
 	ContentSequence []indexedResponse `yaml:"contentSequence,omitempty"`
 	// the test scope
 	Scope string `yaml:"scope,omitempty"`
+	// headers in the response
+	Headers map[string]string `yaml:"headers,omitempty"`
 }
 
 // serverConfig holds the Marathon server configuration
@@ -159,6 +163,10 @@ func newFakeMarathonEndpoint(t *testing.T, configs *configContainer) *endpoint {
 				// Index < 0 indicates a static response.
 				if response.Index < 0 || response.Index == fakeRespIndex {
 					writer.Header().Add("Content-Type", "application/json")
+					for k, v := range response.Headers {
+						writer.Header().Add(k, v)
+					}
+
 					writer.Write([]byte(response.Content))
 					return
 				}
@@ -286,6 +294,7 @@ func initFakeMarathonResponses(t *testing.T) {
 						// Index -1 indicates a static response.
 						Index:   -1,
 						Content: method.Content,
+						Headers: method.Headers,
 					},
 				}
 			}

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -667,6 +667,467 @@
       "deploymentId": "83b215a6-4e26-4e44-9333-5c385eda6438",
       "version": "2014-08-26T07:37:50.462Z"
     }
+- uri: /v2/pods
+  method: HEAD
+- uri: /v2/pods/fake-pod::status
+  method: GET
+  content: |
+    {
+      "id": "/fake-pod",
+      "spec": {
+        "id": "/fake-pod",
+        "labels": {
+          "key": "value"
+        },
+        "version": "2014-08-18T22:36:41.451Z",
+        "user": "nobody",
+        "environment": {
+          "key": {
+            "secret": "secret0"
+          }
+        },
+        "containers": [],
+        "secrets": {
+          "secret0": {
+            "source": "source0"
+          }
+        },
+        "volumes": [],
+        "networks": [],
+        "scaling": {
+          "kind": "fixed",
+          "instances": 1
+        },
+        "scheduling": {}
+      },
+      "status": "STABLE",
+      "statusSince": "2017-07-13T21:33:17.349Z",
+      "instances": [
+        {
+          "id": "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003",
+          "status": "STABLE",
+          "statusSince": "2017-07-13T21:33:17.349Z",
+          "conditions": [],
+          "agentHostname": "192.168.99.100",
+          "resources": {
+            "cpus": 0.1,
+            "mem": 64,
+            "disk": 0,
+            "gpus": 0
+          },
+          "networks": [],
+          "containers": [
+            {
+              "name": "container1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-07-13T21:33:17.349Z",
+              "conditions": [],
+              "containerId": "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003.container1",
+              "endpoints": [],
+              "resources": {
+                "cpus": 0.1,
+                "mem": 32,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-07-13T21:33:17.349Z",
+              "lastChanged": "2017-07-13T21:33:17.349Z"
+            }
+          ],
+          "specReference": "/v2/pods/fake-pod::versions/2017-07-13T21:33:07.389Z",
+          "lastUpdated": "2017-07-13T21:33:17.349Z",
+          "lastChanged": "2017-07-13T21:33:17.349Z"
+        }
+      ],
+      "terminationHistory": [],
+      "lastUpdated": "2017-07-13T22:13:46.635Z",
+      "lastChanged": "2017-07-13T21:33:17.349Z"
+    }
+- uri: /v2/pods/::status
+  method: GET
+  content: |
+    [
+      {
+        "id": "/fake-pod",
+        "spec": {
+          "id": "/fake-pod",
+          "labels": {
+            "key": "value"
+          },
+          "version": "2014-08-18T22:36:41.451Z",
+          "user": "nobody",
+          "environment": {
+            "key": {
+              "secret": "secret0"
+            }
+          },
+          "containers": [],
+          "secrets": {
+            "secret0": {
+              "source": "source0"
+            }
+          },
+          "volumes": [],
+          "networks": [],
+          "scaling": {
+            "kind": "fixed",
+            "instances": 1
+          },
+          "scheduling": {}
+        },
+        "status": "STABLE",
+        "statusSince": "2017-07-13T21:33:17.349Z",
+        "instances": [
+          {
+            "id": "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003",
+            "status": "STABLE",
+            "statusSince": "2017-07-13T21:33:17.349Z",
+            "conditions": [],
+            "agentHostname": "192.168.99.100",
+            "resources": {
+              "cpus": 0.1,
+              "mem": 64,
+              "disk": 0,
+              "gpus": 0
+            },
+            "networks": [],
+            "containers": [
+              {
+                "name": "container1",
+                "status": "TASK_RUNNING",
+                "statusSince": "2017-07-13T21:33:17.349Z",
+                "conditions": [],
+                "containerId": "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003.container1",
+                "endpoints": [],
+                "resources": {
+                  "cpus": 0.1,
+                  "mem": 32,
+                  "disk": 0,
+                  "gpus": 0
+                },
+                "lastUpdated": "2017-07-13T21:33:17.349Z",
+                "lastChanged": "2017-07-13T21:33:17.349Z"
+              }
+            ],
+            "specReference": "/v2/pods/fake-pod::versions/2017-07-13T21:33:07.389Z",
+            "lastUpdated": "2017-07-13T21:33:17.349Z",
+            "lastChanged": "2017-07-13T21:33:17.349Z"
+          }
+        ],
+        "terminationHistory": [],
+        "lastUpdated": "2017-07-13T22:13:46.635Z",
+        "lastChanged": "2017-07-13T21:33:17.349Z"
+      }
+    ]
+- uri: /v2/pods/fake-pod
+  method: GET
+  content: |
+    {
+      "id": "/fake-pod",
+      "labels": {
+          "key": "value"
+      },
+      "version": "2014-08-18T22:36:41.451Z",
+      "user": "nobody",
+      "environment": {
+          "key": "value",
+          "key": {
+              "secret": "secret0"
+          }
+      },
+      "containers": [
+      ],
+      "secrets": {
+          "secret0": {
+              "source": "source0"
+          }
+      },
+      "volumes": [
+
+      ],
+      "networks": [
+
+      ],
+      "scaling": {
+          "kind": "fixed",
+          "instances": 1
+      },
+      "scheduling": {
+
+      }
+    }
+- uri: /v2/pods
+  method: GET
+  content: |
+    [
+      {
+        "id": "/fake-pod",
+        "labels": {
+            "key": "value"
+        },
+        "version": "2014-08-18T22:36:41.451Z",
+        "user": "nobody",
+        "environment": {
+            "key": "value",
+            "key": {
+                "secret": "secret0"
+            }
+        },
+        "containers": [
+        ],
+        "secrets": {
+            "secret0": {
+                "source": "source0"
+            }
+        },
+        "volumes": [
+
+        ],
+        "networks": [
+
+        ],
+        "scaling": {
+            "kind": "fixed",
+            "instances": 1
+        },
+        "scheduling": {
+
+        }
+      }
+    ]
+- uri: /v2/pods
+  method: POST
+  content: |
+    {
+      "id": "/fake-pod",
+      "labels": {
+          "key": "value"
+      },
+      "version": "2014-08-18T22:36:41.451Z",
+      "user": "nobody",
+      "environment": {
+          "key": "value",
+          "key": {
+              "secret": "secret0"
+          }
+      },
+      "containers": [
+      ],
+      "secrets": {
+          "secret0": {
+              "source": "source0"
+          }
+      },
+      "volumes": [
+
+      ],
+      "networks": [
+
+      ],
+      "scaling": {
+          "kind": "fixed",
+          "instances": 1
+      },
+      "scheduling": {
+
+      }
+    }
+- uri: /v2/pods/fake-pod?force=true
+  method: PUT
+  content: |
+    {
+      "id": "/fake-pod",
+      "labels": {
+          "key": "value"
+      },
+      "version": "2014-08-18T22:36:41.451Z",
+      "user": "nobody",
+      "environment": {
+          "key": "value",
+          "key": {
+              "secret": "secret0"
+          }
+      },
+      "containers": [
+      ],
+      "secrets": {
+          "secret0": {
+              "source": "source0"
+          }
+      },
+      "volumes": [
+
+      ],
+      "networks": [
+
+      ],
+      "scaling": {
+          "kind": "fixed",
+          "instances": 2
+      },
+      "scheduling": {
+
+      }
+    }
+- uri: /v2/pods/fake-pod?force=true
+  method: DELETE
+  headers:
+    "Marathon-Deployment-Id": "c0e7434c-df47-4d23-99f1-78bd78662231"
+- uri: /v2/pods/fake-pod::versions
+  method: GET
+  content: |
+    [
+        "2014-08-18T22:36:41.451Z"
+    ]
+- uri: /v2/pods/fake-pod::versions/2014-08-18T22:36:41.451Z
+  method: GET
+  content: |
+    {
+      "id": "/fake-pod",
+      "labels": {
+          "key": "value"
+      },
+      "version": "2014-08-18T22:36:41.451Z",
+      "user": "nobody",
+      "environment": {
+          "key": "value",
+          "key": {
+              "secret": "secret0"
+          }
+      },
+      "containers": [
+      ],
+      "secrets": {
+          "secret0": {
+              "source": "source0"
+          }
+      },
+      "volumes": [
+
+      ],
+      "networks": [
+
+      ],
+      "scaling": {
+          "kind": "fixed",
+          "instances": 1
+      },
+      "scheduling": {
+
+      }
+    }
+- uri: /v2/pods/fake-pod::instances/fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003
+  method: DELETE
+  content: |
+    {
+      "instanceId": {
+        "idString": "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003"
+      },
+      "agentInfo": {
+        "host": "192.168.99.100",
+        "agentId": "c3856950-ab1a-4aea-b1a8-168397c0fb33-S9",
+        "attributes": [
+          "CgR6b25lEAMqBgoEcGR4Mw==",
+          "CgZyZWdpb24QABoJCQAAAAAAAAhA",
+          "Cg1pbnN0YW5jZV90eXBlEAMqCQoHY29tcHV0ZQ==",
+          "CgNzZG4QAyoKCghjb250cmFpbA==",
+          "CgJvcxADKgkKB2NlbnRvczc="
+        ]
+      },
+      "tasksMap": {
+        "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003.container1": {
+          "taskId": "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003.container1",
+          "runSpecVersion": "2017-07-13T23:04:05.835Z",
+          "status": {
+            "stagedAt": "2017-07-13T23:04:05.939Z",
+            "startedAt": "2017-07-13T23:04:07.767Z",
+            "mesosStatus": "Ck0KS3JjbHVzdGVyX2Rjb3Mtc2lkZWNhci5pbnN0YW5jZS05MWU5YzE1OC02ODFmLTExZTctYTE4ZS03MGIzZDU4MDAwMDMuc2lkZWNhchABKikKJ2MzODU2OTUwLWFiMWEtNGFlYS1iMWE4LTE2ODM5N2MwZmIzMy1TOTGxw/AZ/1nWQTpFCkNpbnN0YW5jZS1yY2x1c3Rlcl9kY29zLXNpZGVjYXIuOTFlOWMxNTgtNjgxZi0xMWU3LWExOGUtNzBiM2Q1ODAwMDAzSAJaEOVRUUkSVEbRi5mOLzx0bnxqkgIKvAEimAEKLgoRcmNsdXN0ZXIubG9jYXRpb24SGWdsb2JhbHJpb3QucGR4Mi5yY2x1c3RlcjEKGgoOcmNsdXN0ZXIuZ3JvdXASCHJjbHVzdGVyCiQKFHJjbHVzdGVyLmFwcGxpY2F0aW9uEgxkY29zLXNpZGVjYXIKJAoKRENPU19TUEFDRRIWL3JjbHVzdGVyL2Rjb3Mtc2lkZWNhcioRCAESDTEwLjQwLjI1My4xMDAyDHJjbHVzdGVyLWNuaRiiWyJOCiRiYjgyOWJiZS02OWExLTRiMmQtYWE4Zi0zNGY5MDQ4YjNiMjUSJgokY2UyZDFjOWMtZGQ5MC00MDYyLWI1M2QtYzdkNTRiZGI2ODI1",
+            "condition": {
+              "str": "running"
+            },
+            "networkInfo": {
+              "hostName": "192.168.99.100",
+              "hostPorts": [],
+              "ipAddresses": [
+                {
+                  "ipAddress": "192.168.99.100",
+                  "protocol": "IPv4"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "runSpecVersion": "2017-07-13T23:04:05.835Z",
+      "state": {
+        "condition": {
+          "str": "running"
+        },
+        "since": "2017-07-13T23:04:07.767Z",
+        "activeSince": "2017-07-13T23:04:07.767Z"
+      },
+      "unreachableStrategy": {
+        "inactiveAfterSeconds": 300,
+        "expungeAfterSeconds": 600
+      }
+    }
+- uri: /v2/pods/fake-pod::instances
+  method: DELETE
+  content: |
+    [
+      {
+        "instanceId": {
+          "idString": "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003"
+        },
+        "agentInfo": {
+          "host": "192.168.99.100",
+          "agentId": "c3856950-ab1a-4aea-b1a8-168397c0fb33-S9",
+          "attributes": [
+            "CgR6b25lEAMqBgoEcGR4Mw==",
+            "CgZyZWdpb24QABoJCQAAAAAAAAhA",
+            "Cg1pbnN0YW5jZV90eXBlEAMqCQoHY29tcHV0ZQ==",
+            "CgNzZG4QAyoKCghjb250cmFpbA==",
+            "CgJvcxADKgkKB2NlbnRvczc="
+          ]
+        },
+        "tasksMap": {
+          "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003.container1": {
+            "taskId": "fake-pod.instance-dc6cfe60-6812-11e7-a18e-70b3d5800003.container1",
+            "runSpecVersion": "2017-07-13T23:04:05.835Z",
+            "status": {
+              "stagedAt": "2017-07-13T23:04:05.939Z",
+              "startedAt": "2017-07-13T23:04:07.767Z",
+              "mesosStatus": "Ck0KS3JjbHVzdGVyX2Rjb3Mtc2lkZWNhci5pbnN0YW5jZS05MWU5YzE1OC02ODFmLTExZTctYTE4ZS03MGIzZDU4MDAwMDMuc2lkZWNhchABKikKJ2MzODU2OTUwLWFiMWEtNGFlYS1iMWE4LTE2ODM5N2MwZmIzMy1TOTGxw/AZ/1nWQTpFCkNpbnN0YW5jZS1yY2x1c3Rlcl9kY29zLXNpZGVjYXIuOTFlOWMxNTgtNjgxZi0xMWU3LWExOGUtNzBiM2Q1ODAwMDAzSAJaEOVRUUkSVEbRi5mOLzx0bnxqkgIKvAEimAEKLgoRcmNsdXN0ZXIubG9jYXRpb24SGWdsb2JhbHJpb3QucGR4Mi5yY2x1c3RlcjEKGgoOcmNsdXN0ZXIuZ3JvdXASCHJjbHVzdGVyCiQKFHJjbHVzdGVyLmFwcGxpY2F0aW9uEgxkY29zLXNpZGVjYXIKJAoKRENPU19TUEFDRRIWL3JjbHVzdGVyL2Rjb3Mtc2lkZWNhcioRCAESDTEwLjQwLjI1My4xMDAyDHJjbHVzdGVyLWNuaRiiWyJOCiRiYjgyOWJiZS02OWExLTRiMmQtYWE4Zi0zNGY5MDQ4YjNiMjUSJgokY2UyZDFjOWMtZGQ5MC00MDYyLWI1M2QtYzdkNTRiZGI2ODI1",
+              "condition": {
+                "str": "running"
+              },
+              "networkInfo": {
+                "hostName": "192.168.99.100",
+                "hostPorts": [],
+                "ipAddresses": [
+                  {
+                    "ipAddress": "192.168.99.100",
+                    "protocol": "IPv4"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "runSpecVersion": "2017-07-13T23:04:05.835Z",
+        "state": {
+          "condition": {
+            "str": "running"
+          },
+          "since": "2017-07-13T23:04:07.767Z",
+          "activeSince": "2017-07-13T23:04:07.767Z"
+        },
+        "unreachableStrategy": {
+          "inactiveAfterSeconds": 300,
+          "expungeAfterSeconds": 600
+        }
+      }
+    ]
 - uri: /v2/groups
   method: GET
   content: |

--- a/volume.go
+++ b/volume.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 Devin All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package marathon
+
+// PodVolume describes a volume on the host
+type PodVolume struct {
+	Name string `json:"name,omitempty"`
+	Host string `json:"host,omitempty"`
+}
+
+// PodVolumeMount describes how to mount a volume into a task
+type PodVolumeMount struct {
+	Name      string `json:"name,omitempty"`
+	MountPath string `json:"mountPath,omitempty"`
+}
+
+// NewPodVolume creates a new PodVolume
+func NewPodVolume(name, path string) *PodVolume {
+	return &PodVolume{
+		Name: name,
+		Host: path,
+	}
+}
+
+// NewPodVolumeMount creates a new PodVolumeMount
+func NewPodVolumeMount(name, mount string) *PodVolumeMount {
+	return &PodVolumeMount{
+		Name:      name,
+		MountPath: mount,
+	}
+}


### PR DESCRIPTION
New in Marathon 1.4.0: https://github.com/mesosphere/marathon/blob/master/changelog.md#changes-from-1310-to-140

This adds support to query pods. Testing done on a Marathon deployment with version 1.4.2. 

Addresses issue https://github.com/gambol99/go-marathon/issues/271