### PR TITLE
Task residency support

### DIFF
--- a/application.go
+++ b/application.go
@@ -100,6 +100,7 @@ type Application struct {
 	LastTaskFailure       *LastTaskFailure        `json:"lastTaskFailure,omitempty"`
 	Fetch                 *[]Fetch                `json:"fetch,omitempty"`
 	IPAddressPerTask      *IPAddressPerTask       `json:"ipAddress,omitempty"`
+	Residency             *Residency              `json:"residence,omitempty"`
 	Secrets               *map[string]Secret      `json:"-"`
 }
 
@@ -600,6 +601,13 @@ func (r *Application) SetUnreachableStrategy(us UnreachableStrategy) *Applicatio
 // the unreachable strategy set (setting it to nil will keep the current value).
 func (r *Application) EmptyUnreachableStrategy() *Application {
 	r.UnreachableStrategy = &UnreachableStrategy{}
+	return r
+}
+
+func (r *Application) SetResidency(whenLost TaskLostBehaviorType) *Application {
+	r.Residency = &Residency{
+		TaskLostBehavior: whenLost,
+	}
 	return r
 }
 

--- a/application.go
+++ b/application.go
@@ -604,10 +604,20 @@ func (r *Application) EmptyUnreachableStrategy() *Application {
 	return r
 }
 
+// SetResidency sets behavior for resident applications, an application is resident when
+// it has local persistent volumes set
 func (r *Application) SetResidency(whenLost TaskLostBehaviorType) *Application {
 	r.Residency = &Residency{
 		TaskLostBehavior: whenLost,
 	}
+	return r
+}
+
+// EmptyResidency explicitly empties the residency -- use this if
+// you need to empty the residency of an application that already has
+// the residency set (setting it to nil will keep the current value).
+func (r *Application) EmptyResidency() *Application {
+	r.Residency = &Residency{}
 	return r
 }
 

--- a/application.go
+++ b/application.go
@@ -100,7 +100,7 @@ type Application struct {
 	LastTaskFailure       *LastTaskFailure        `json:"lastTaskFailure,omitempty"`
 	Fetch                 *[]Fetch                `json:"fetch,omitempty"`
 	IPAddressPerTask      *IPAddressPerTask       `json:"ipAddress,omitempty"`
-	Residency             *Residency              `json:"residence,omitempty"`
+	Residency             *Residency              `json:"residency,omitempty"`
 	Secrets               *map[string]Secret      `json:"-"`
 }
 

--- a/application_test.go
+++ b/application_test.go
@@ -551,6 +551,10 @@ func verifyApplication(application *Application, t *testing.T) {
 	assert.NotNil(t, application.Tasks)
 	assert.Equal(t, len(*application.HealthChecks), 1)
 	assert.Equal(t, len(application.Tasks), 2)
+	assert.Equal(t, application.Residency, &Residency{
+		TaskLostBehavior:                 TaskLostBehaviorTypeRelaunchAfterTimeout,
+		RelaunchEscalationTimeoutSeconds: 60,
+	})
 }
 
 func TestApplication(t *testing.T) {

--- a/residency.go
+++ b/residency.go
@@ -1,23 +1,48 @@
+/*
+Copyright 2017 Ondrej Smola All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package marathon
 
+import "time"
+
+// TaskLostBehaviorType sets action taken when the resident task is lost
 type TaskLostBehaviorType string
 
 const (
-	TaskLostBehaviorTypeWaitForever          TaskLostBehaviorType = "WAIT_FOREVER"
+	// TaskLostBehaviorTypeWaitForever sets to don`t take any action when the resident task is lost
+	TaskLostBehaviorTypeWaitForever TaskLostBehaviorType = "WAIT_FOREVER"
+	// TaskLostBehaviorTypeRelaunchAfterTimeout sets to try relaunch the lost resident task
+	// on another node after relaunch escalation timeout
 	TaskLostBehaviorTypeRelaunchAfterTimeout TaskLostBehaviorType = "RELAUNCH_AFTER_TIMEOUT"
 )
 
+// Residency defines how terminal states of tasks with local persistent volumes are handled
 type Residency struct {
 	TaskLostBehavior                 TaskLostBehaviorType `json:"taskLostBehavior,omitempty"`
 	RelaunchEscalationTimeoutSeconds int                  `json:"relaunchEscalationTimeoutSeconds,omitempty"`
 }
 
+// SetTaskLostBehavior sets the residency behavior
 func (r *Residency) SetTaskLostBehavior(behavior TaskLostBehaviorType) *Residency {
 	r.TaskLostBehavior = behavior
 	return r
 }
 
-func (r *Residency) SetRelaunchEscalationTimeoutSeconds(seconds int) *Residency {
-	r.RelaunchEscalationTimeoutSeconds = seconds
+// SetRelaunchEscalationTimeout sets the residency relaunch escalation timeout with seconds precision
+func (r *Residency) SetRelaunchEscalationTimeout(timeout time.Duration) *Residency {
+	r.RelaunchEscalationTimeoutSeconds = int(timeout.Seconds())
 	return r
 }

--- a/residency.go
+++ b/residency.go
@@ -22,10 +22,10 @@ import "time"
 type TaskLostBehaviorType string
 
 const (
-	// TaskLostBehaviorTypeWaitForever sets to don`t take any action when the resident task is lost
+	// TaskLostBehaviorTypeWaitForever indicates to not take any action when the resident task is lost
 	TaskLostBehaviorTypeWaitForever TaskLostBehaviorType = "WAIT_FOREVER"
-	// TaskLostBehaviorTypeRelaunchAfterTimeout sets to try relaunch the lost resident task
-	// on another node after relaunch escalation timeout
+	// TaskLostBehaviorTypeWaitForever indicates to try relaunching the lost resident task on
+	// another node after the relaunch escalation timeout has elapsed
 	TaskLostBehaviorTypeRelaunchAfterTimeout TaskLostBehaviorType = "RELAUNCH_AFTER_TIMEOUT"
 )
 

--- a/residency.go
+++ b/residency.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Ondrej Smola All rights reserved.
+Copyright 2017 Rohith All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/residency.go
+++ b/residency.go
@@ -1,0 +1,23 @@
+package marathon
+
+type TaskLostBehaviorType string
+
+const (
+	TaskLostBehaviorTypeWaitForever          TaskLostBehaviorType = "WAIT_FOREVER"
+	TaskLostBehaviorTypeRelaunchAfterTimeout TaskLostBehaviorType = "RELAUNCH_AFTER_TIMEOUT"
+)
+
+type Residency struct {
+	TaskLostBehavior                 TaskLostBehaviorType `json:"taskLostBehavior,omitempty"`
+	RelaunchEscalationTimeoutSeconds int                  `json:"relaunchEscalationTimeoutSeconds,omitempty"`
+}
+
+func (r *Residency) SetTaskLostBehavior(behavior TaskLostBehaviorType) *Residency {
+	r.TaskLostBehavior = behavior
+	return r
+}
+
+func (r *Residency) SetRelaunchEscalationTimeoutSeconds(seconds int) *Residency {
+	r.RelaunchEscalationTimeoutSeconds = seconds
+	return r
+}

--- a/residency_test.go
+++ b/residency_test.go
@@ -18,7 +18,6 @@ package marathon
 
 import (
 	"testing"
-
 	"time"
 
 	"github.com/stretchr/testify/assert"

--- a/residency_test.go
+++ b/residency_test.go
@@ -1,0 +1,25 @@
+package marathon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResidency(t *testing.T) {
+	app := NewDockerApplication()
+
+	app = app.SetResidency(TaskLostBehaviorTypeWaitForever)
+
+	if assert.NotNil(t, app.Residency) {
+		res := app.Residency
+
+		assert.Equal(t, res.TaskLostBehavior, TaskLostBehaviorTypeWaitForever)
+
+		res.SetRelaunchEscalationTimeoutSeconds(60)
+		assert.Equal(t, app.Residency.RelaunchEscalationTimeoutSeconds, 60)
+
+		res.SetTaskLostBehavior(TaskLostBehaviorTypeRelaunchAfterTimeout)
+		assert.Equal(t, res.TaskLostBehavior, TaskLostBehaviorTypeRelaunchAfterTimeout)
+	}
+}

--- a/residency_test.go
+++ b/residency_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Ondrej Smola All rights reserved.
+Copyright 2017 Rohith All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/residency_test.go
+++ b/residency_test.go
@@ -1,7 +1,25 @@
+/*
+Copyright 2017 Ondrej Smola All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package marathon
 
 import (
 	"testing"
+
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,10 +34,17 @@ func TestResidency(t *testing.T) {
 
 		assert.Equal(t, res.TaskLostBehavior, TaskLostBehaviorTypeWaitForever)
 
-		res.SetRelaunchEscalationTimeoutSeconds(60)
-		assert.Equal(t, app.Residency.RelaunchEscalationTimeoutSeconds, 60)
+		res.SetRelaunchEscalationTimeout(2525 * time.Millisecond)
+		// should be trimmed to seconds precision
+		assert.Equal(t, app.Residency.RelaunchEscalationTimeoutSeconds, 2)
 
 		res.SetTaskLostBehavior(TaskLostBehaviorTypeRelaunchAfterTimeout)
 		assert.Equal(t, res.TaskLostBehavior, TaskLostBehaviorTypeRelaunchAfterTimeout)
+	}
+
+	app = app.EmptyResidency()
+
+	if assert.NotNil(t, app.Residency) {
+		assert.Equal(t, app.Residency, &Residency{})
 	}
 }

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -481,10 +481,10 @@
             10000
         ],
         "requirePorts": false,
-            "residency" : {
-                "taskLostBehavior" : "RELAUNCH_AFTER_TIMEOUT",
-                "relaunchEscalationTimeoutSeconds" : 60
-            },
+        "residency" : {
+            "taskLostBehavior" : "RELAUNCH_AFTER_TIMEOUT",
+            "relaunchEscalationTimeoutSeconds" : 60
+        },
         "storeUrls": [],
         "tasks": [
             {

--- a/tests/rest-api/methods.yml
+++ b/tests/rest-api/methods.yml
@@ -61,6 +61,10 @@
           0
       ],
       "requirePorts": false,
+      "residency" : {
+          "taskLostBehavior" : "RELAUNCH_AFTER_TIMEOUT",
+          "relaunchEscalationTimeoutSeconds" : 60
+      },
       "storeUrls": [],
       "upgradeStrategy": {
           "minimumHealthCapacity": 0.5,
@@ -201,6 +205,10 @@
                 10001
             ],
             "requirePorts": false,
+            "residency" : {
+                "taskLostBehavior" : "RELAUNCH_AFTER_TIMEOUT",
+                "relaunchEscalationTimeoutSeconds" : 60
+            },
             "storeUrls": [],
             "tasksRunning": 2,
             "tasksStaged": 0,
@@ -353,6 +361,10 @@
             10000
         ],
         "requirePorts": false,
+        "residency" : {
+            "taskLostBehavior" : "RELAUNCH_AFTER_TIMEOUT",
+            "relaunchEscalationTimeoutSeconds" : 60
+        },
         "storeUrls": [],
         "tasks": [
             {
@@ -469,6 +481,10 @@
             10000
         ],
         "requirePorts": false,
+            "residency" : {
+                "taskLostBehavior" : "RELAUNCH_AFTER_TIMEOUT",
+                "relaunchEscalationTimeoutSeconds" : 60
+            },
         "storeUrls": [],
         "tasks": [
             {
@@ -598,6 +614,10 @@
             10000
         ],
         "requirePorts": false,
+        "residency" : {
+            "taskLostBehavior" : "RELAUNCH_AFTER_TIMEOUT",
+            "relaunchEscalationTimeoutSeconds" : 60
+        },
         "storeUrls": [],
         "tasks": [
             {
@@ -1248,6 +1268,10 @@
                 10001
             ],
             "requirePorts": false,
+            "residency" : {
+                "taskLostBehavior" : "RELAUNCH_AFTER_TIMEOUT",
+                "relaunchEscalationTimeoutSeconds" : 60
+            },
             "storeUrls": [],
             "tasksRunning": 2,
             "tasksStaged": 0,


### PR DESCRIPTION
Described partially in [Persistent Volumes](https://mesosphere.github.io/marathon/docs/persistent-volumes.html)
[RAML type description](https://github.com/mesosphere/marathon/blob/48bfffdbb2920732ba726ce19ade6deb00121794/docs/docs/rest-api/public/api/v2/types/app.raml#L23l)