### PR TITLE
Deflake tests.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -39,6 +39,9 @@ type cluster struct {
 	members []*member
 	// the marathon HTTP client to ensure consistency in requests
 	client *httpClient
+	// healthCheckInterval is the interval by which we probe down nodes for
+	// availability again.
+	healthCheckInterval time.Duration
 }
 
 // member represents an individual endpoint
@@ -94,8 +97,9 @@ func newCluster(client *httpClient, marathonURL string, isDCOS bool) (*cluster, 
 	}
 
 	return &cluster{
-		client:  client,
-		members: members,
+		client:              client,
+		members:             members,
+		healthCheckInterval: 5 * time.Second,
 	}, nil
 }
 
@@ -130,20 +134,21 @@ func (c *cluster) markDown(endpoint string) {
 // healthCheckNode performs a health check on the node and when active updates the status
 func (c *cluster) healthCheckNode(node *member) {
 	// step: wait for the node to become active ... we are assuming a /ping is enough here
-	for {
+	ticker := time.NewTicker(c.healthCheckInterval)
+	defer ticker.Stop()
+	for range ticker.C {
 		req, err := c.client.buildMarathonRequest("GET", node.endpoint, "ping", nil)
 		if err == nil {
 			res, err := c.client.Do(req)
 			if err == nil && res.StatusCode == 200 {
+				// step: mark the node as active again
+				c.Lock()
+				node.status = memberStatusUp
+				c.Unlock()
 				break
 			}
 		}
-		<-time.After(time.Duration(5 * time.Second))
 	}
-	// step: mark the node as active again
-	c.Lock()
-	defer c.Unlock()
-	node.status = memberStatusUp
 }
 
 // activeMembers returns a list of active members

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -373,8 +373,10 @@ func TestConnectToSSESuccess(t *testing.T) {
 	client.hosts.members = append(client.hosts.members, &member{endpoint: endpoint.Server.httpSrv.URL})
 
 	// Connection should work as one of the Marathon members is up
-	_, err := client.connectToSSE()
-	assert.NoError(t, err, "expected no error in connectToSSE")
+	stream, err := client.connectToSSE()
+	if assert.NoError(t, err, "expected no error in connectToSSE") {
+		stream.Close()
+	}
 }
 
 func TestConnectToSSEFailure(t *testing.T) {
@@ -388,8 +390,10 @@ func TestConnectToSSEFailure(t *testing.T) {
 	client := endpoint.Client.(*marathonClient)
 
 	// No Marathon member is up, we should get an error
-	_, err := client.connectToSSE()
-	assert.Error(t, err, "expected error in connectToSSE when all cluster members are down")
+	stream, err := client.connectToSSE()
+	if !assert.Error(t, err, "expected error in connectToSSE when all cluster members are down") {
+		stream.Close()
+	}
 }
 
 func TestRegisterSEESubscriptionReconnectsStreamOnError(t *testing.T) {


### PR DESCRIPTION
- Fix race in `TestMarkDown`.
- Properly close SSE streams in `TestConnectToSSE{Success,Failure}`.