### PR TITLE
Default SSE HTTP client to regular client if given.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,16 @@ marathonURL := "http://10.241.1.71:8080/cluster,10.241.1.72:8080/cluster,10.241.
 
 If you specify a `DCOSToken` in the configuration file but do not pass a custom URL path, `/marathon` will be used.
 
-### Custom HTTP Clients
+### Customizing the HTTP Clients
 
-If you wish to override http clients used by the API; use cases bypassing TLS verification, load root CA's or change the timeouts etc, you can pass a custom client in the config.
-There are two clients:
-* `HTTPClient` used for non SSE subscription requests. By default a http.Client with 10 seconds timeout for a whole request.
-* `HTTPSSEClient` used only for SSE subscription requests. `HTTPSSEClient` can't have response read timeout set. By default a http.Client with 5 seconds timeout for dial and tls handshake and 10 seconds timeout for response header receive.
+HTTP clients with reasonable timeouts are used by default. It is possible to pass custom clients to the configuration though if the behavior should be customized (e.g., to bypass TLS verification, load root CAs, or change timeouts).
+
+Two clients can be given independently of each other:
+
+- `HTTPClient` used only for (non-SSE) HTTP API requests. By default, an http.Client with 10 seconds timeout for the entire request is used.
+- `HTTPSSEClient` used only for SSE-based subscription requests. Note that `HTTPSSEClient` cannot have a response read timeout set as this breaks SSE communication; trying to do so will lead to an error during the SSE connection setup. By default, an http.Client with 5 seconds timeout for dial and TLS handshake, and 10 seconds timeout for response headers received is used.
+
+If no `HTTPSSEClient` is given but an `HTTPClient` is, it will be used for SSE subscriptions as well (thereby overriding the default SSE HTTP client).
 
 ```Go
 marathonURL := "http://10.241.1.71:8080"

--- a/client.go
+++ b/client.go
@@ -215,18 +215,18 @@ type newRequestError struct {
 // NewClient creates a new marathon client
 //		config:			the configuration to use
 func NewClient(config Config) (Marathon, error) {
-	// step: if no http client, set to default
-	if config.HTTPClient == nil {
-		config.HTTPClient = defaultHTTPClient
-	}
-
+	// step: if the SSE HTTP client is missing, prefer a configured regular
+	// client, and otherwise use the default SSE HTTP client.
 	if config.HTTPSSEClient == nil {
 		config.HTTPSSEClient = defaultHTTPSSEClient
-	} else if config.HTTPSSEClient.Timeout != 0 {
-		return nil, fmt.Errorf(
-			"Global timeout must not be set on custom HTTP client for SSE connections (got %s)",
-			config.HTTPSSEClient.Timeout,
-		)
+		if config.HTTPClient != nil {
+			config.HTTPSSEClient = config.HTTPClient
+		}
+	}
+
+	// step: if a regular HTTP client is missing, use the default one.
+	if config.HTTPClient == nil {
+		config.HTTPClient = defaultHTTPClient
 	}
 
 	// step: if no polling wait time is set, default to 500 milliseconds.

--- a/subscription.go
+++ b/subscription.go
@@ -103,8 +103,7 @@ func (r *marathonClient) registerSubscription() error {
 	case EventsTransportCallback:
 		return r.registerCallbackSubscription()
 	case EventsTransportSSE:
-		r.registerSSESubscription()
-		return nil
+		return r.registerSSESubscription()
 	default:
 		return fmt.Errorf("the events transport: %d is not supported", r.config.EventsTransport)
 	}
@@ -167,9 +166,16 @@ func (r *marathonClient) registerCallbackSubscription() error {
 // connect to the SSE stream and to process the received events. To establish
 // the connection it tries the active cluster members until no more member is
 // active. When this happens it will retry to get a connection every 5 seconds.
-func (r *marathonClient) registerSSESubscription() {
+func (r *marathonClient) registerSSESubscription() error {
 	if r.subscribedToSSE {
-		return
+		return nil
+	}
+
+	if r.config.HTTPSSEClient.Timeout != 0 {
+		return fmt.Errorf(
+			"global timeout must not be set for SSE connections (found %s) -- remove global timeout from HTTP client or provide separate SSE HTTP client without global timeout",
+			r.config.HTTPSSEClient.Timeout,
+		)
 	}
 
 	go func() {
@@ -187,6 +193,7 @@ func (r *marathonClient) registerSSESubscription() {
 	}()
 
 	r.subscribedToSSE = true
+	return nil
 }
 
 // connectToSSE tries to establish an *eventsource.Stream to any of the Marathon cluster members, marking the

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -298,6 +298,22 @@ func TestUnsubscribe(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSSEWithGlobalTimeout(t *testing.T) {
+	clientCfg := NewDefaultConfig()
+	clientCfg.HTTPSSEClient = &http.Client{
+		Timeout: 1 * time.Second,
+	}
+	config := configContainer{
+		client: &clientCfg,
+	}
+	config.client.EventsTransport = EventsTransportSSE
+	endpoint := newFakeMarathonEndpoint(t, &config)
+	defer endpoint.Close()
+
+	_, err := endpoint.Client.AddEventsListener(EventIDApplications)
+	assert.Error(t, err)
+}
+
 func TestEventStreamEventsReceived(t *testing.T) {
 	require.True(t, len(testCases) > 1, "must have at least 2 test cases to end prematurely")
 


### PR DESCRIPTION
This restores compatibility for users that only pass a single, custom HTTP client.

We also move the check for an illegal global timeout to the SSE connection setup phase so that users not interested in SSE subscriptions are not bothered unnecessarily.

Fixes #309.

@marco-jantke could you review this one too please? I know you did a fair amount of work on the HTTP clients as well. Thanks!

/cc @mtweten @ondrej-smola