### PR TITLE
Run vet before test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,9 @@ check-format:
 		exit 1; \
 	fi
 
-test: deps
+test: deps vet
 	@echo "--> Running go tests"
 	@go test -race -v
-	@$(MAKE) vet
 	@$(MAKE) cover
 
 examples:


### PR DESCRIPTION
vet is much cheaper, so we want to bail out early prior to starting the more heavyweight tests.