### PR TITLE
Fixed the types in  PodUpgrade struct

### DIFF
--- a/pod_scheduling.go
+++ b/pod_scheduling.go
@@ -25,8 +25,8 @@ type PodBackoff struct {
 
 // PodUpgrade describes the policy for upgrading a pod in-place
 type PodUpgrade struct {
-	MinimumHealthCapacity *int `json:"minimumHealthCapacity,omitempty"`
-	MaximumOverCapacity   *int `json:"maximumOverCapacity,omitempty"`
+	MinimumHealthCapacity *float64 `json:"minimumHealthCapacity,omitempty"`
+	MaximumOverCapacity   *float64 `json:"maximumOverCapacity,omitempty"`
 }
 
 // PodPlacement supports constraining which hosts a pod is placed on


### PR DESCRIPTION
@BUGFIX Fixed the types in PodUpgrade struct, types changed from int to float64 since it should be a number between 0 and 1. 