### PR TITLE
Add persistent volume support for Pod volumes

### DIFF
--- a/volume.go
+++ b/volume.go
@@ -18,14 +18,16 @@ package marathon
 
 // PodVolume describes a volume on the host
 type PodVolume struct {
-	Name string `json:"name,omitempty"`
-	Host string `json:"host,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	Host       string            `json:"host,omitempty"`
+	Persistent *PersistentVolume `json:"persistent,omitempty"`
 }
 
 // PodVolumeMount describes how to mount a volume into a task
 type PodVolumeMount struct {
 	Name      string `json:"name,omitempty"`
 	MountPath string `json:"mountPath,omitempty"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
 }
 
 // NewPodVolume creates a new PodVolume
@@ -42,4 +44,10 @@ func NewPodVolumeMount(name, mount string) *PodVolumeMount {
 		Name:      name,
 		MountPath: mount,
 	}
+}
+
+// SetPersistentVolume sets the persistence settings of a PodVolume
+func (pv *PodVolume) SetPersistentVolume(p *PersistentVolume) *PodVolume {
+	pv.Persistent = p
+	return pv
 }


### PR DESCRIPTION
Adds support for persistent pod volumes. The JSON schema is the same as for Applications with persistent volumes, so it was simply a matter of adding `persistent` to the `PodVolume` struct.

Relevant documentation:
https://docs.mesosphere.com/1.11/storage/persistent-volume/#create-a-pod-with-a-local-persistent-volume
