### PR TITLE
add file-based secret

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -53,6 +53,7 @@ type Volume struct {
 	External      *ExternalVolume   `json:"external,omitempty"`
 	Mode          string            `json:"mode,omitempty"`
 	Persistent    *PersistentVolume `json:"persistent,omitempty"`
+	Secret        string            `json:"secret,omitempty"`
 }
 
 // PersistentVolumeType is the a persistent docker volume to be mounted
@@ -170,6 +171,13 @@ func (v *Volume) SetPersistentVolume() *PersistentVolume {
 	ev := &PersistentVolume{}
 	v.Persistent = ev
 	return ev
+}
+
+// SetSecretVolume defines secret and containerPath for volume
+func (v *Volume) SetSecretVolume(containerPath, secret string) *Volume {
+	v.ContainerPath = containerPath
+	v.Secret = secret
+	return v
 }
 
 // EmptyPersistentVolume empties the persistent volume definition

--- a/docker_test.go
+++ b/docker_test.go
@@ -141,6 +141,19 @@ func TestVolume(t *testing.T) {
 	assert.Equal(t, (*container.Volumes)[1].Mode, "R")
 }
 
+func TestSecretVolume(t *testing.T) {
+	container := NewDockerApplication().Container
+
+	container.Volume("", "oldPath", "")
+
+	sv1 := (*container.Volumes)[0]
+	assert.Equal(t, sv1.ContainerPath, "oldPath")
+
+	sv1.SetSecretVolume("newPath", "some-secret")
+	assert.Equal(t, sv1.ContainerPath, "newPath")
+	assert.Equal(t, sv1.Secret, "some-secret")
+}
+
 func TestExternalVolume(t *testing.T) {
 	container := NewDockerApplication().Container
 


### PR DESCRIPTION
According to https://docs.mesosphere.com/1.11/security/ent/secrets/use-secrets/. Secrets can be file-based and mounted as volumes

```
{
  "id": "developer/service",
  "cmd": "sleep 100",
  "container": {
     "type": "MESOS",
     "volumes": [
      {
        "containerPath": "path",
        "secret": "secretpassword"
      }
    ]
  },
  "secrets": {
    "secretpassword": {
      "source": "developer/databasepassword"
    }
  }
}
```