### PR TITLE
Add role to Application and Pod

### DIFF
--- a/application.go
+++ b/application.go
@@ -104,6 +104,7 @@ type Application struct {
 	IPAddressPerTask      *IPAddressPerTask       `json:"ipAddress,omitempty"`
 	Residency             *Residency              `json:"residency,omitempty"`
 	Secrets               *map[string]Secret      `json:"-"`
+	Role                  *string                 `json:"role,omitempty"`
 }
 
 // ApplicationVersions is a collection of application versions for a specific app in marathon

--- a/pod.go
+++ b/pod.go
@@ -36,6 +36,7 @@ type Pod struct {
 	Scaling           *PodScalingPolicy    `json:"scaling,omitempty"`
 	Scheduling        *PodSchedulingPolicy `json:"scheduling,omitempty"`
 	ExecutorResources *ExecutorResources   `json:"executorResources,omitempty"`
+	Role              *string              `json:"role,omitempty"`
 }
 
 // PodScalingPolicy is the scaling policy of the pod


### PR DESCRIPTION
This adds an optional `Role` field to the `Application` and `Pod` definitions as per https://github.com/mesosphere/marathon/commit/02b775ea427d2cada6765226e2c4caf885add5d6