### PR TITLE
BUG do not use omitempty on plain bool

### DIFF
--- a/examples/pods/main.go
+++ b/examples/pods/main.go
@@ -56,7 +56,7 @@ func createRawPod() *marathon.Pod {
 			Image: &marathon.PodContainerImage{
 				Kind:      "DOCKER",
 				ID:        "nginx",
-				ForcePull: true,
+				ForcePull: marathon.Bool(true),
 			},
 			VolumeMounts: []*marathon.PodVolumeMount{
 				&marathon.PodVolumeMount{

--- a/pod_container.go
+++ b/pod_container.go
@@ -51,9 +51,9 @@ type PodExec struct {
 // PodArtifact describes how to obtain a generic artifact for a pod
 type PodArtifact struct {
 	URI        string `json:"uri,omitempty"`
-	Extract    bool   `json:"extract,omitempty"`
-	Executable bool   `json:"executable,omitempty"`
-	Cache      bool   `json:"cache,omitempty"`
+	Extract    *bool  `json:"extract,omitempty"`
+	Executable *bool  `json:"executable,omitempty"`
+	Cache      *bool  `json:"cache,omitempty"`
 	DestPath   string `json:"destPath,omitempty"`
 }
 

--- a/pod_container_image.go
+++ b/pod_container_image.go
@@ -31,7 +31,7 @@ const (
 type PodContainerImage struct {
 	Kind       ImageType   `json:"kind,omitempty"`
 	ID         string      `json:"id,omitempty"`
-	ForcePull  bool        `json:"forcePull,omitempty"`
+	ForcePull  *bool       `json:"forcePull,omitempty"`
 	PullConfig *PullConfig `json:"pullConfig,omitempty"`
 }
 

--- a/pod_marshalling_test.go
+++ b/pod_marshalling_test.go
@@ -100,3 +100,19 @@ func TestPodEnvironmentVariableMarshal(t *testing.T) {
 		assert.Equal(t, targetString, pod)
 	}
 }
+
+func TestPodContainerArtifactBoolMarshal(t *testing.T) {
+	targetString := `{"containers":[{"artifacts":[{"extract":false}],"lifecycle":{}}]}`
+
+	testPod := new(Pod)
+	testArtifact := new(PodArtifact)
+	testArtifact.Extract = Bool(false)
+	testContainer := new(PodContainer)
+	testContainer.AddArtifact(testArtifact)
+	testPod.AddContainer(testContainer)
+
+	pod, err := json.Marshal(testPod)
+	if assert.NoError(t, err) {
+		assert.Equal(t, targetString, string(pod))
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -133,3 +133,8 @@ func addOptions(s string, opt interface{}) (string, error) {
 	u.RawQuery = qs.Encode()
 	return u.String(), nil
 }
+
+// Bool returns a pointer to the passed in bool value
+func Bool(b bool) *bool {
+	return &b
+}

--- a/volume.go
+++ b/volume.go
@@ -27,7 +27,7 @@ type PodVolume struct {
 type PodVolumeMount struct {
 	Name      string `json:"name,omitempty"`
 	MountPath string `json:"mountPath,omitempty"`
-	ReadOnly  bool   `json:"readOnly,omitempty"`
+	ReadOnly  *bool  `json:"readOnly,omitempty"`
 }
 
 // NewPodVolume creates a new PodVolume


### PR DESCRIPTION
# The Problem
The issue occurred by creating a pod with containers that use an artifact with `extract = false`. When this is posted to marathon `omitempty` will omit the false bool from the marshalled JSON. But the default value for extract is `true` ( see https://github.com/mesosphere/marathon/blob/master/docs/docs/rest-api/public/api/v2/types/artifact.raml#L13 ). So reading the pod again leads to `extract = true`. With the current implementation a user never wont be able to set this to `false` as it gets omitted.

# Solution
do not use `omitempty` with bool values to ensure being able to set them to false.