### PR TITLE
added pullConfig to pod

### DIFF
--- a/pod_container_image.go
+++ b/pod_container_image.go
@@ -29,9 +29,10 @@ const (
 
 // PodContainerImage describes how to retrieve the container image
 type PodContainerImage struct {
-	Kind      ImageType `json:"kind,omitempty"`
-	ID        string    `json:"id,omitempty"`
-	ForcePull bool      `json:"forcePull,omitempty"`
+	Kind       ImageType   `json:"kind,omitempty"`
+	ID         string      `json:"id,omitempty"`
+	ForcePull  bool        `json:"forcePull,omitempty"`
+	PullConfig *PullConfig `json:"pullConfig,omitempty"`
 }
 
 // NewPodContainerImage creates an empty PodContainerImage
@@ -48,6 +49,13 @@ func (i *PodContainerImage) SetKind(typ ImageType) *PodContainerImage {
 // SetID sets the ID of the image
 func (i *PodContainerImage) SetID(id string) *PodContainerImage {
 	i.ID = id
+	return i
+}
+
+// SetPullConfig adds *PullConfig to PodContainerImage
+func (i *PodContainerImage) SetPullConfig(pullConfig *PullConfig) *PodContainerImage {
+	i.PullConfig = pullConfig
+
 	return i
 }
 

--- a/pod_test.go
+++ b/pod_test.go
@@ -169,3 +169,15 @@ func TestGetPodByVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, pod.ID, fakePodName)
 }
+
+func TestAddPodImagePullConfig(t *testing.T) {
+	container := new(PodContainer)
+	container.Image = new(PodContainerImage)
+	pullConfig := NewPullConfig("pullConfig-secret")
+
+	container.Image.SetPullConfig(pullConfig)
+
+	if assert.NotNil(t, container.Image.PullConfig) {
+		assert.Equal(t, "pullConfig-secret", container.Image.PullConfig.Secret)
+	}
+}


### PR DESCRIPTION
this is an addition to #359 enabling pullConfig on pods. This allows DC/OS marathon users using secrets to pull from private registries with auth.

- should finally close #357
- adds pullConfig in a similar way as for marathon app